### PR TITLE
3 add trame version on crystal structure tools

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
     - pyqtdarktheme
     - blinker
     - nova-mvvm>=0.11.1
-    - nova-trame>=0.17.2
+    - nova-trame>=0.25.0
     - pyqt5
     - trame-matplotlib
     - trame-vtk

--- a/src/NeuXtalViz/components/visualization_panel/view_qt.py
+++ b/src/NeuXtalViz/components/visualization_panel/view_qt.py
@@ -350,22 +350,6 @@ class VisPanelWidget(QWidget):
         self.axes_box.clicked.connect(self.view_model.change_axes)
         self.proj_box.clicked.connect(self.view_model.change_projection)
 
-    def start_worker_pool(self, worker):
-        """
-        Create a worker pool.
-
-        """
-
-        self.threadpool.start_worker_pool(worker)
-
-    def worker(self, task):
-        """
-        Worker task.
-
-        """
-
-        return Worker(task)
-
     def set_info(self, status):
         """
         Update status information.

--- a/src/NeuXtalViz/components/visualization_panel/view_trame.py
+++ b/src/NeuXtalViz/components/visualization_panel/view_trame.py
@@ -172,9 +172,9 @@ class VisualizationPanel:
             with vuetify.VProgressLinear(
                 v_model=f"{self.name}_progress",
                 height=20,
-                striped=("progress < 100",),
+                striped=(f"{self.name}_progress < 100",),
             ):
-                html.Span("{{ status }}")
+                html.Span(f"{{{{ {self.name}_status }}}}")
 
     def update_view(self, _):
         self.view.update()

--- a/src/NeuXtalViz/components/visualization_panel/view_trame.py
+++ b/src/NeuXtalViz/components/visualization_panel/view_trame.py
@@ -221,6 +221,7 @@ class VisualizationPanel:
     def trigger_show_axes(self, data):
         self.axis_data = data
 
+
     def change_projection(self, parallel_projection):
         """
         Enable or disable parallel projection.

--- a/src/NeuXtalViz/components/visualization_panel/view_trame.py
+++ b/src/NeuXtalViz/components/visualization_panel/view_trame.py
@@ -50,16 +50,20 @@ class VisualizationPanel:
         return self.server.state
 
     def create_ui(self):
-        with vuetify.VContainer(classes="mr-2 pa-0", fluid=True):
-            with GridLayout(columns=5):
-                with VBoxLayout(valign="start"):
+        with vuetify.VContainer(
+            classes="d-flex flex-column mr-2 pa-0",
+            fluid=True,
+            style="height: calc(100vh - 140px);",
+        ):
+            with GridLayout(classes="mb-2", columns=5, gap="1em", valign="start"):
+                with VBoxLayout(valign="start", gap="0.5em"):
                     vuetify.VBtn("Save Screenshot", click=self.save_screenshot)
                     vuetify.VBtn("Reset View", classes="my-1", click=self.reset_view)
                     vuetify.VBtn("Reset Camera", click=self.reset_camera)
                 with VBoxLayout(column_span=3):
                     with vuetify.VTabs(
                         v_model=f"{self.name}_controls.camera_tab",
-                        classes="mb-1",
+                        classes="pl-2",
                         density="compact",
                         update_modelValue=f"flushState('{self.name}_controls')",
                     ):
@@ -67,7 +71,11 @@ class VisualizationPanel:
                         vuetify.VTab("Manual View", value=2)
                     with vuetify.VWindow(v_model=f"{self.name}_controls.camera_tab"):
                         with vuetify.VWindowItem(value=1):
-                            with GridLayout(columns=6):
+                            with GridLayout(
+                                classes="border-sm border-primary pa-1 rounded",
+                                columns=6,
+                                gap="0.5em",
+                            ):
                                 vuetify.VBtn("+Qx", click=self.plotter.view_yz)
                                 vuetify.VBtn("+Qy", click=self.plotter.view_zx)
                                 vuetify.VBtn("+Qz", click=self.plotter.view_xy)
@@ -81,48 +89,74 @@ class VisualizationPanel:
                                 vuetify.VBtn("b", click=self.view_model.view_ca)
                                 vuetify.VBtn("c", click=self.view_model.view_ab)
                         with vuetify.VWindowItem(value=2):
-                            with GridLayout(columns=12, halign="center"):
-                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_axis_type[0] }}}}")
-                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_axis_type[1] }}}}")
-                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_axis_type[2] }}}}")
-                                InputField(
-                                    v_model="controls.manual_axis_type",
-                                    column_span=3,
-                                    type="select",
-                                )
-                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_up_axis_type[0] }}}}")
-                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_up_axis_type[1] }}}}")
-                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_up_axis_type[2] }}}}")
-                                InputField(
-                                    v_model=f"{self.name}_controls.manual_up_axis_type",
-                                    column_span=3,
-                                    type="select",
-                                )
-                                InputField(v_model=f"{self.name}_controls.manual_axes[0]")
-                                InputField(v_model=f"{self.name}_controls.manual_axes[1]")
-                                InputField(v_model=f"{self.name}_controls.manual_axes[2]")
-                                vuetify.VBtn(
-                                    "View Axis",
-                                    column_span=3,
-                                    click=self.view_model.view_manual,
-                                )
-                                InputField(v_model=f"{self.name}_controls.manual_up_axes[0]")
-                                InputField(v_model=f"{self.name}_controls.manual_up_axes[1]")
-                                InputField(v_model=f"{self.name}_controls.manual_up_axes[2]")
-                                vuetify.VBtn(
-                                    "View Up Axis",
-                                    column_span=3,
-                                    click=self.view_model.view_up_manual,
-                                )
+                            with VBoxLayout(
+                                classes="border-sm border-primary mb-2 pa-1 rounded"
+                            ):
+                                with HBoxLayout():
+                                    InputField(
+                                        v_model=f"{self.name}_controls.manual_axis_type",
+                                        type="select",
+                                    )
+                                    InputField(
+                                        v_model=f"{self.name}_controls.manual_up_axis_type",
+                                        type="select",
+                                    )
 
-                with VBoxLayout(valign="start"):
+                                with HBoxLayout(valign="center"):
+                                    InputField(
+                                        v_model=f"{self.name}_controls.manual_axes[0]",
+                                        label=(
+                                            f"{self.name}_controls.manual_axis_type[0]",
+                                        ),
+                                    )
+                                    InputField(
+                                        v_model=f"{self.name}_controls.manual_axes[1]",
+                                        label=(
+                                            f"{self.name}_controls.manual_axis_type[1]",
+                                        ),
+                                    )
+                                    InputField(
+                                        v_model=f"{self.name}_controls.manual_axes[2]",
+                                        label=(
+                                            f"{self.name}_controls.manual_axis_type[2]",
+                                        ),
+                                    )
+                                    vuetify.VBtn(
+                                        "View Axis", click=self.view_model.view_manual
+                                    )
+                                    InputField(
+                                        v_model=f"{self.name}_controls.manual_up_axes[0]",
+                                        label=(
+                                            f"{self.name}_controls.manual_up_axis_type[0]",
+                                        ),
+                                    )
+                                    InputField(
+                                        v_model=f"{self.name}_controls.manual_up_axes[1]",
+                                        label=(
+                                            f"{self.name}_controls.manual_up_axis_type[1]",
+                                        ),
+                                    )
+                                    InputField(
+                                        v_model=f"{self.name}_controls.manual_up_axes[2]",
+                                        label=(
+                                            f"{self.name}_controls.manual_up_axis_type[2]",
+                                        ),
+                                    )
+                                    vuetify.VBtn(
+                                        "View Up Axis",
+                                        click=self.view_model.view_up_manual,
+                                    )
+
+                with VBoxLayout(valign="start", gap="0.5em"):
                     InputField(
                         v_model=f"{self.name}_controls.reciprocal_lattice",
                         density="compact",
                         type="checkbox",
                     )
                     InputField(
-                        v_model=f"{self.name}_controls.show_axes", density="compact", type="checkbox"
+                        v_model=f"{self.name}_controls.show_axes",
+                        density="compact",
+                        type="checkbox",
                     )
                     InputField(
                         v_model=f"{self.name}_controls.parallel_projection",
@@ -130,13 +164,12 @@ class VisualizationPanel:
                         type="checkbox",
                     )
 
-            with vuetify.VSheet(classes="mb-2", style="height: 40vh;"):
+            with vuetify.VSheet(classes="flex-1-0 mb-2"):
                 self.view = get_viewer(self.plotter.pv_plotter)
                 self.view.ui(add_menu=False, mode="server")
 
             with vuetify.VTabs(
                 v_model=f"{self.name}_controls.oriented_lattice_tab",
-                classes="mb-1",
                 density="compact",
                 update_modelValue=f"flushState('{self.name}_controls')",
             ):
@@ -144,30 +177,67 @@ class VisualizationPanel:
                 vuetify.VTab("Sample Orientation", value=2)
             with vuetify.VWindow(v_model=f"{self.name}_controls.oriented_lattice_tab"):
                 with vuetify.VWindowItem(value=1):
-                    with GridLayout(columns=3):
-                        InputField(v_model=f"{self.name}_lattice_parameters.a", readonly=True)
-                        InputField(v_model=f"{self.name}_lattice_parameters.b", readonly=True)
-                        with HBoxLayout():
-                            InputField(v_model=f"{self.name}_lattice_parameters.c", readonly=True)
-                            vuetify.VLabel("Å")
-                        InputField(v_model=f"{self.name}_lattice_parameters.alpha", readonly=True)
-                        InputField(v_model=f"{self.name}_lattice_parameters.beta", readonly=True)
+                    with GridLayout(
+                        classes="border-sm border-primary mb-2 pa-1 rounded", columns=3
+                    ):
+                        InputField(
+                            v_model=f"{self.name}_lattice_parameters.a", readonly=True
+                        )
+                        InputField(
+                            v_model=f"{self.name}_lattice_parameters.b", readonly=True
+                        )
                         with HBoxLayout():
                             InputField(
-                                v_model=f"{self.name}_lattice_parameters.gamma", readonly=True
+                                v_model=f"{self.name}_lattice_parameters.c",
+                                readonly=True,
+                            )
+                            vuetify.VLabel("Å")
+                        InputField(
+                            v_model=f"{self.name}_lattice_parameters.alpha",
+                            readonly=True,
+                        )
+                        InputField(
+                            v_model=f"{self.name}_lattice_parameters.beta",
+                            readonly=True,
+                        )
+                        with HBoxLayout():
+                            InputField(
+                                v_model=f"{self.name}_lattice_parameters.gamma",
+                                readonly=True,
                             )
                             vuetify.VLabel("°")
                 with vuetify.VWindowItem(value=2):
-                    with HBoxLayout():
-                        vuetify.VLabel("u:")
-                        InputField(v_model=f"{self.name}_lattice_parameters.u[0]", readonly=True)
-                        InputField(v_model=f"{self.name}_lattice_parameters.u[1]", readonly=True)
-                        InputField(v_model=f"{self.name}_lattice_parameters.u[2]", readonly=True)
-                    with HBoxLayout():
-                        vuetify.VLabel("v:")
-                        InputField(v_model=f"{self.name}_lattice_parameters.v[0]", readonly=True)
-                        InputField(v_model=f"{self.name}_lattice_parameters.v[1]", readonly=True)
-                        InputField(v_model=f"{self.name}_lattice_parameters.v[2]", readonly=True)
+                    with VBoxLayout(
+                        classes="border-sm border-primary mb-2 pa-1 rounded"
+                    ):
+                        with HBoxLayout():
+                            vuetify.VLabel("u:")
+                            InputField(
+                                v_model=f"{self.name}_lattice_parameters.u[0]",
+                                readonly=True,
+                            )
+                            InputField(
+                                v_model=f"{self.name}_lattice_parameters.u[1]",
+                                readonly=True,
+                            )
+                            InputField(
+                                v_model=f"{self.name}_lattice_parameters.u[2]",
+                                readonly=True,
+                            )
+                        with HBoxLayout():
+                            vuetify.VLabel("v:")
+                            InputField(
+                                v_model=f"{self.name}_lattice_parameters.v[0]",
+                                readonly=True,
+                            )
+                            InputField(
+                                v_model=f"{self.name}_lattice_parameters.v[1]",
+                                readonly=True,
+                            )
+                            InputField(
+                                v_model=f"{self.name}_lattice_parameters.v[2]",
+                                readonly=True,
+                            )
 
             with vuetify.VProgressLinear(
                 v_model=f"{self.name}_progress",
@@ -220,7 +290,6 @@ class VisualizationPanel:
 
     def trigger_show_axes(self, data):
         self.axis_data = data
-
 
     def change_projection(self, parallel_projection):
         """

--- a/src/NeuXtalViz/components/visualization_panel/view_trame.py
+++ b/src/NeuXtalViz/components/visualization_panel/view_trame.py
@@ -232,4 +232,4 @@ class VisualizationPanel:
         self.plotter.view_vector(vecs)
 
     def view_up_vector(self, vec):
-        self.plotter.set_viewup(vec)
+        self.plotter.view_up_vector(vec)

--- a/src/NeuXtalViz/components/visualization_panel/view_trame.py
+++ b/src/NeuXtalViz/components/visualization_panel/view_trame.py
@@ -170,7 +170,7 @@ class VisualizationPanel:
 
             with vuetify.VTabs(
                 v_model=f"{self.name}_controls.oriented_lattice_tab",
-                density="compact",
+                classes="pl-2",
                 update_modelValue=f"flushState('{self.name}_controls')",
             ):
                 vuetify.VTab("Lattice Parameters", value=1)

--- a/src/NeuXtalViz/components/visualization_panel/view_trame.py
+++ b/src/NeuXtalViz/components/visualization_panel/view_trame.py
@@ -3,23 +3,30 @@ from asyncio import ensure_future, sleep
 import numpy as np
 import pyvista as pv
 from io import BytesIO
+
+from nova.mvvm.trame_binding import TrameBinding
 from nova.trame.view.components import InputField
 from nova.trame.view.layouts import GridLayout, HBoxLayout, VBoxLayout
 from pyvista.trame.ui import get_viewer
 from trame.widgets import client, html
 from trame.widgets import vuetify3 as vuetify
 
+from NeuXtalViz.components.visualization_panel.view_model import VizViewModel
+from NeuXtalViz.views.shared.base_plotter import BasePlotter
+
 
 class VisualizationPanel:
-    def __init__(self, server, view_model):
+    def __init__(self, name, pv_plotter, model, server):
         self.server = server
-        self.view_model = view_model
-        self.view_model.controls_bind.connect("controls")
-        self.view_model.lattice_parameters_bind.connect("lattice_parameters")
+        self.name = name
+        binding = TrameBinding(server.state)
+        self.view_model = VizViewModel(model, binding)
+        self.view_model.controls_bind.connect(f"{name}_controls")
+        self.view_model.lattice_parameters_bind.connect(f"{name}_lattice_parameters")
         self.view_model.show_axes_bind.connect(self.trigger_show_axes)
         self.view_model.parallel_projection_bind.connect(self.change_projection)
-        self.view_model.progress_bind.connect("progress")
-        self.view_model.status_bind.connect("status")
+        self.view_model.progress_bind.connect(f"{name}_progress")
+        self.view_model.status_bind.connect(f"{name}_status")
         self.view_model.up_vector_bind.connect(self.view_up_vector)
         self.view_model.update_view_bind.connect(self.update_view)
         self.view_model.vector_bind.connect(self.view_vector)
@@ -30,7 +37,8 @@ class VisualizationPanel:
         ensure_future(self.show_axes_loop())
 
         self.camera_position = None
-        self.plotter = self.create_plotter()
+        self.plotter = BasePlotter(pv_plotter)
+
         self.js_download = client.JSEval(
             exec="utils.download($event[0], $event[1], 'image/png')"
         ).exec
@@ -41,12 +49,6 @@ class VisualizationPanel:
     def state(self):
         return self.server.state
 
-    def create_plotter(self):
-        plotter = pv.Plotter(off_screen=True)
-        plotter.background_color = "#f0f0f0"
-
-        return plotter
-
     def create_ui(self):
         with vuetify.VContainer(classes="mr-2 pa-0", fluid=True):
             with GridLayout(columns=5):
@@ -54,17 +56,16 @@ class VisualizationPanel:
                     vuetify.VBtn("Save Screenshot", click=self.save_screenshot)
                     vuetify.VBtn("Reset View", classes="my-1", click=self.reset_view)
                     vuetify.VBtn("Reset Camera", click=self.reset_camera)
-
                 with VBoxLayout(column_span=3):
                     with vuetify.VTabs(
-                        v_model="controls.camera_tab",
+                        v_model=f"{self.name}_controls.camera_tab",
                         classes="mb-1",
                         density="compact",
-                        update_modelValue="flushState('controls')",
+                        update_modelValue=f"flushState('{self.name}_controls')",
                     ):
                         vuetify.VTab("Direction View", value=1)
                         vuetify.VTab("Manual View", value=2)
-                    with vuetify.VWindow(v_model="controls.camera_tab"):
+                    with vuetify.VWindow(v_model=f"{self.name}_controls.camera_tab"):
                         with vuetify.VWindowItem(value=1):
                             with GridLayout(columns=6):
                                 vuetify.VBtn("+Qx", click=self.plotter.view_yz)
@@ -81,33 +82,33 @@ class VisualizationPanel:
                                 vuetify.VBtn("c", click=self.view_model.view_ab)
                         with vuetify.VWindowItem(value=2):
                             with GridLayout(columns=12, halign="center"):
-                                vuetify.VLabel("{{ controls.manual_axis_type[0] }}")
-                                vuetify.VLabel("{{ controls.manual_axis_type[1] }}")
-                                vuetify.VLabel("{{ controls.manual_axis_type[2] }}")
+                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_axis_type[0] }}}}")
+                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_axis_type[1] }}}}")
+                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_axis_type[2] }}}}")
                                 InputField(
                                     v_model="controls.manual_axis_type",
                                     column_span=3,
                                     type="select",
                                 )
-                                vuetify.VLabel("{{ controls.manual_up_axis_type[0] }}")
-                                vuetify.VLabel("{{ controls.manual_up_axis_type[1] }}")
-                                vuetify.VLabel("{{ controls.manual_up_axis_type[2] }}")
+                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_up_axis_type[0] }}}}")
+                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_up_axis_type[1] }}}}")
+                                vuetify.VLabel(f"{{{{ {self.name}_controls.manual_up_axis_type[2] }}}}")
                                 InputField(
-                                    v_model="controls.manual_up_axis_type",
+                                    v_model=f"{self.name}_controls.manual_up_axis_type",
                                     column_span=3,
                                     type="select",
                                 )
-                                InputField(v_model="controls.manual_axes[0]")
-                                InputField(v_model="controls.manual_axes[1]")
-                                InputField(v_model="controls.manual_axes[2]")
+                                InputField(v_model=f"{self.name}_controls.manual_axes[0]")
+                                InputField(v_model=f"{self.name}_controls.manual_axes[1]")
+                                InputField(v_model=f"{self.name}_controls.manual_axes[2]")
                                 vuetify.VBtn(
                                     "View Axis",
                                     column_span=3,
                                     click=self.view_model.view_manual,
                                 )
-                                InputField(v_model="controls.manual_up_axes[0]")
-                                InputField(v_model="controls.manual_up_axes[1]")
-                                InputField(v_model="controls.manual_up_axes[2]")
+                                InputField(v_model=f"{self.name}_controls.manual_up_axes[0]")
+                                InputField(v_model=f"{self.name}_controls.manual_up_axes[1]")
+                                InputField(v_model=f"{self.name}_controls.manual_up_axes[2]")
                                 vuetify.VBtn(
                                     "View Up Axis",
                                     column_span=3,
@@ -116,60 +117,60 @@ class VisualizationPanel:
 
                 with VBoxLayout(valign="start"):
                     InputField(
-                        v_model="controls.reciprocal_lattice",
+                        v_model=f"{self.name}_controls.reciprocal_lattice",
                         density="compact",
                         type="checkbox",
                     )
                     InputField(
-                        v_model="controls.show_axes", density="compact", type="checkbox"
+                        v_model=f"{self.name}_controls.show_axes", density="compact", type="checkbox"
                     )
                     InputField(
-                        v_model="controls.parallel_projection",
+                        v_model=f"{self.name}_controls.parallel_projection",
                         density="compact",
                         type="checkbox",
                     )
 
             with vuetify.VSheet(classes="mb-2", style="height: 40vh;"):
-                self.view = get_viewer(self.plotter)
+                self.view = get_viewer(self.plotter.pv_plotter)
                 self.view.ui(add_menu=False, mode="server")
 
             with vuetify.VTabs(
-                v_model="controls.oriented_lattice_tab",
+                v_model=f"{self.name}_controls.oriented_lattice_tab",
                 classes="mb-1",
                 density="compact",
-                update_modelValue="flushState('controls')",
+                update_modelValue=f"flushState('{self.name}_controls')",
             ):
                 vuetify.VTab("Lattice Parameters", value=1)
                 vuetify.VTab("Sample Orientation", value=2)
-            with vuetify.VWindow(v_model="controls.oriented_lattice_tab"):
+            with vuetify.VWindow(v_model=f"{self.name}_controls.oriented_lattice_tab"):
                 with vuetify.VWindowItem(value=1):
                     with GridLayout(columns=3):
-                        InputField(v_model="lattice_parameters.a", readonly=True)
-                        InputField(v_model="lattice_parameters.b", readonly=True)
+                        InputField(v_model=f"{self.name}_lattice_parameters.a", readonly=True)
+                        InputField(v_model=f"{self.name}_lattice_parameters.b", readonly=True)
                         with HBoxLayout():
-                            InputField(v_model="lattice_parameters.c", readonly=True)
+                            InputField(v_model=f"{self.name}_lattice_parameters.c", readonly=True)
                             vuetify.VLabel("Å")
-                        InputField(v_model="lattice_parameters.alpha", readonly=True)
-                        InputField(v_model="lattice_parameters.beta", readonly=True)
+                        InputField(v_model=f"{self.name}_lattice_parameters.alpha", readonly=True)
+                        InputField(v_model=f"{self.name}_lattice_parameters.beta", readonly=True)
                         with HBoxLayout():
                             InputField(
-                                v_model="lattice_parameters.gamma", readonly=True
+                                v_model=f"{self.name}_lattice_parameters.gamma", readonly=True
                             )
                             vuetify.VLabel("°")
                 with vuetify.VWindowItem(value=2):
                     with HBoxLayout():
                         vuetify.VLabel("u:")
-                        InputField(v_model="lattice_parameters.u[0]", readonly=True)
-                        InputField(v_model="lattice_parameters.u[1]", readonly=True)
-                        InputField(v_model="lattice_parameters.u[2]", readonly=True)
+                        InputField(v_model=f"{self.name}_lattice_parameters.u[0]", readonly=True)
+                        InputField(v_model=f"{self.name}_lattice_parameters.u[1]", readonly=True)
+                        InputField(v_model=f"{self.name}_lattice_parameters.u[2]", readonly=True)
                     with HBoxLayout():
                         vuetify.VLabel("v:")
-                        InputField(v_model="lattice_parameters.v[0]", readonly=True)
-                        InputField(v_model="lattice_parameters.v[1]", readonly=True)
-                        InputField(v_model="lattice_parameters.v[2]", readonly=True)
+                        InputField(v_model=f"{self.name}_lattice_parameters.v[0]", readonly=True)
+                        InputField(v_model=f"{self.name}_lattice_parameters.v[1]", readonly=True)
+                        InputField(v_model=f"{self.name}_lattice_parameters.v[2]", readonly=True)
 
             with vuetify.VProgressLinear(
-                v_model="progress",
+                v_model=f"{self.name}_progress",
                 height=20,
                 striped=("progress < 100",),
             ):
@@ -180,16 +181,12 @@ class VisualizationPanel:
 
     def save_screenshot(self):
         data = BytesIO()
-        self.plotter.screenshot(data)
+        self.plotter.pv_plotter.screenshot(data)
         data.seek(0)
         self.js_download(("neuxtalviz.png", data.read()))
 
     def clear_scene(self):
-        self.plotter.clear_plane_widgets()
-        self.plotter.clear_actors()
-
-        if self.camera_position is not None:
-            self.camera_position = self.plotter.camera_position
+        self.plotter.clear_scene()
 
     def reset_camera(self):
         """
@@ -200,36 +197,17 @@ class VisualizationPanel:
         self.plotter.reset_camera()
 
     def reset_scene(self):
-        if self.camera_position is not None:
-            self.plotter.camera_position = self.camera_position
-        else:
-            self.reset_view()
+        self.plotter.reset_scene()
 
     def reset_view(self, negative=False):
         """
         Reset the view.
 
         """
-
-        self.plotter.reset_camera()
-        self.plotter.view_isometric(negative)
-        self.camera_position = self.plotter.camera_position
+        self.plotter.reset_view(negative)
 
     def show_axes(self, data):
-        T, reciprocal_lattice, show_axes = data
-
-        if not show_axes:
-            self.plotter.hide_axes()
-        elif T is not None:
-            t = pv._vtk.vtkMatrix4x4()
-            for i in range(3):
-                for j in range(3):
-                    t.SetElement(i, j, T[i, j])
-            if reciprocal_lattice:
-                actor = self.plotter.add_axes(xlabel="a*", ylabel="b*", zlabel="c*")
-            else:
-                actor = self.plotter.add_axes(xlabel="a", ylabel="b", zlabel="c")
-            actor.SetUserMatrix(t)
+        self.plotter.show_axes(data)
         self.update_view(None)
 
     async def show_axes_loop(self):
@@ -248,18 +226,10 @@ class VisualizationPanel:
         Enable or disable parallel projection.
 
         """
-
-        if parallel_projection:
-            self.plotter.enable_parallel_projection()
-        else:
-            self.plotter.disable_parallel_projection()
+        self.plotter.change_projection(parallel_projection)
 
     def view_vector(self, vecs):
-        if len(vecs) == 2:
-            vec = np.cross(vecs[0], vecs[1])
-            self.pv_plotter.view_vector(vecs[0], vec)
-        else:
-            self.plotter.view_vector(vecs)
+        self.plotter.view_vector(vecs)
 
     def view_up_vector(self, vec):
         self.plotter.set_viewup(vec)

--- a/src/NeuXtalViz/main.py
+++ b/src/NeuXtalViz/main.py
@@ -8,16 +8,21 @@ def main():
         choices=["qt", "trame"],
         help="The frontend in which to display the application.",
     )
+    # This just matches the Trame --server argument.
+    parser.add_argument("--server", action="store_true")
+    parser.set_defaults(server=False)
 
     args = parser.parse_args()
 
     match args.frontend:
         case "qt":
             from NeuXtalViz.qt.gui import gui
+
             gui()
         case "trame":
             from NeuXtalViz.trame.gui import trame
-            trame()
+
+            trame(open_browser=not args.server)
 
 
 if __name__ == "__main__":

--- a/src/NeuXtalViz/qt/gui.py
+++ b/src/NeuXtalViz/qt/gui.py
@@ -233,7 +233,7 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 
 
 def gui():
-    sys.excepthook = handle_exception
+#    sys.excepthook = handle_exception
     app = QApplication(sys.argv)
     qdarktheme.setup_theme("light")
     # app.setStyleSheet(qdarkstyle.load_stylesheet(palette=LightPalette))

--- a/src/NeuXtalViz/qt/new_views/atom.py
+++ b/src/NeuXtalViz/qt/new_views/atom.py
@@ -58,10 +58,10 @@ class AtomView(QWidget):
         self.select_button.clicked.connect(self.view_model.use_isotope)
 
     def update_isotope(self, new_value):
-        self.callback_atom_params("atom_model.current_isotope", new_value)
+        self.callback_atom_params("atom_model.current_isotope", int(new_value))
 
     def on_atom_params_update(self, atom_params: AtomParams):
-        if atom_params.view_dialog == False:
+        if atom_params.show_dialog == False:
             self.close()
             return
         self.set_symbol_name(atom_params.symbol, atom_params.name)
@@ -69,24 +69,21 @@ class AtomView(QWidget):
         self.set_atom_parameters(atom_params.atom_dict, atom_params.neutron_dict)
         self.show()
 
-    def connect_isotopes(self, update_info):
-        self.isotope_combo.currentIndexChanged.connect(update_info)
-
     def set_symbol_name(self, symbol, name):
         self.symbol_label.setText(symbol)
         self.name_label.setText(name)
 
-    def set_isotope_numbers(self, numbers, cur_index):
+    def set_isotope_numbers(self, numbers, cur_isotope):
         try:
-            self.isotope_combo.currentIndexChanged.disconnect(self.update_isotope)
+            self.isotope_combo.currentIndexChanged[str].disconnect(self.update_isotope)
         except Exception:
             pass
 
         self.isotope_combo.clear()
         if numbers is not None:
             self.isotope_combo.addItems(np.array(numbers).astype(str).tolist())
-            self.isotope_combo.setCurrentIndex(cur_index)
-            self.isotope_combo.currentIndexChanged.connect(self.update_isotope)
+            self.isotope_combo.setCurrentText(str(cur_isotope))
+            self.isotope_combo.currentIndexChanged[str].connect(self.update_isotope)
 
     def set_atom_parameters(self, atom, scatt):
         self.z_label.setText(str(atom["z"]))

--- a/src/NeuXtalViz/qt/new_views/base_view.py
+++ b/src/NeuXtalViz/qt/new_views/base_view.py
@@ -514,7 +514,7 @@ class NeuXtalVizWidget(QWidget):
 
         if len(vecs) == 2:
             vec = np.cross(vecs[0], vecs[1])
-            self.plotter.view_vector(vecs[0], vec)
+            self.pv_plotter.view_vector(vecs[0], vec)
         else:
             self.plotter.view_vector(vecs)
 

--- a/src/NeuXtalViz/qt/new_views/crystal_structure_tools.py
+++ b/src/NeuXtalViz/qt/new_views/crystal_structure_tools.py
@@ -341,8 +341,7 @@ class CrystalStructureView(QWidget):
         self.dmin_line.setText(str(controls.minimum_d_spacing or ''))
         self.constrain_parameters(controls.constrain_parameters)
         if controls.current_scatterer_row:
-            if controls.current_scatterer is not None:
-                self.set_atom_table_row(controls.current_scatterer_row[0], controls.current_scatterer)
+            self.atm_table.selectRow(controls.current_scatterer_row[0])
         self.set_atom(controls.current_scatterer)
 
     def process_controls_change(self, key: str, value: Any, element: Any = None) -> None:

--- a/src/NeuXtalViz/qt/new_views/crystal_structure_tools.py
+++ b/src/NeuXtalViz/qt/new_views/crystal_structure_tools.py
@@ -343,7 +343,7 @@ class CrystalStructureView(QWidget):
         if controls.current_scatterer_row:
             if controls.current_scatterer is not None:
                 self.set_atom_table_row(controls.current_scatterer_row[0], controls.current_scatterer)
-            self.set_atom(controls.current_scatterer)
+        self.set_atom(controls.current_scatterer)
 
     def process_controls_change(self, key: str, value: Any, element: Any = None) -> None:
         validate_element(key, value, element)
@@ -547,6 +547,15 @@ class CrystalStructureView(QWidget):
         self.atm_button.setText(isotope)
 
     def set_atom(self, scatterer):
+        if scatterer[0] is None:
+            self.atm_button.setText("")
+            self.x_line.setText("")
+            self.y_line.setText("")
+            self.z_line.setText("")
+            self.occ_line.setText("")
+            self.Uiso_line.setText("")
+            return
+
         atm, *xyz, occ, Uiso = scatterer
         xyz = ["{:.4f}".format(val) for val in xyz]
         occ = "{:.4f}".format(occ)

--- a/src/NeuXtalViz/qt/new_views/crystal_structure_tools.py
+++ b/src/NeuXtalViz/qt/new_views/crystal_structure_tools.py
@@ -56,7 +56,6 @@ class CrystalStructureView(QWidget):
         self.callback_atoms = self.view_model.cs_atoms_bind.connect("cs_atoms", self.on_atoms_update)
 
         self.view_model.cs_factors_bind.connect("cs_factors", self.set_factors)
-        self.view_model.cs_equivalents_bind.connect("cs_equivalents", self.set_equivalents)
 
         layout.addWidget(self.vis_widget)
         self.tab_widget = QTabWidget(self)
@@ -91,9 +90,9 @@ class CrystalStructureView(QWidget):
 
         validator = QDoubleValidator(0.1, 1000, 4, notation=notation)
 
-#        self.a_line.setValidator(validator)
-#        self.b_line.setValidator(validator)
-#        self.c_line.setValidator(validator)
+        #        self.a_line.setValidator(validator)
+        #        self.b_line.setValidator(validator)
+        #        self.c_line.setValidator(validator)
 
         notation = QDoubleValidator.StandardNotation
 
@@ -347,6 +346,7 @@ class CrystalStructureView(QWidget):
     def process_controls_change(self, key: str, value: Any, element: Any = None) -> None:
         validate_element(key, value, element)
         self.callback_controls(key, value)
+
     def process_validation(self, key: str, value: Any, element: Any = None) -> None:
         validate_element(key, value, element)
 
@@ -373,13 +373,16 @@ class CrystalStructureView(QWidget):
             lambda: self.process_controls_change("cs_controls.lattice_constants.c", self.c_line.text(), self.c_line)
         )
         self.alpha_line.editingFinished.connect(
-            lambda: self.process_controls_change("cs_controls.lattice_constants.alpha", self.alpha_line.text(), self.alpha_line)
+            lambda: self.process_controls_change("cs_controls.lattice_constants.alpha", self.alpha_line.text(),
+                                                 self.alpha_line)
         )
         self.beta_line.editingFinished.connect(
-            lambda: self.process_controls_change("cs_controls.lattice_constants.beta", self.beta_line.text(), self.beta_line)
+            lambda: self.process_controls_change("cs_controls.lattice_constants.beta", self.beta_line.text(),
+                                                 self.beta_line)
         )
         self.gamma_line.editingFinished.connect(
-            lambda: self.process_controls_change("cs_controls.lattice_constants.gamma", self.gamma_line.text(), self.gamma_line)
+            lambda: self.process_controls_change("cs_controls.lattice_constants.gamma", self.gamma_line.text(),
+                                                 self.gamma_line)
         )
         self.a_line.textChanged.connect(
             lambda value: self.process_validation("cs_controls.lattice_constants.a", value, self.a_line)
@@ -399,8 +402,6 @@ class CrystalStructureView(QWidget):
         self.gamma_line.textChanged.connect(
             lambda value: self.process_validation("cs_controls.lattice_constants.gamma", value, self.gamma_line)
         )
-
-
 
     def update_scatterer(self):
         scatterer = self.get_current_scatterer()
@@ -613,31 +614,14 @@ class CrystalStructureView(QWidget):
         self.atm_table.selectRow(ind)
 
     def set_factors(self, result):
-        (hkls, ds, F2s) = result
+        factors = result.factors_dict
         self.f2_table.setRowCount(0)
-        self.f2_table.setRowCount(len(hkls))
+        self.f2_table.setRowCount(len(factors))
 
-        for row, (hkl, d, F2) in enumerate(zip(hkls, ds, F2s)):
-            hkl = ["{:.0f}".format(val) for val in hkl]
-            d = "{:.4f}".format(d)
-            F2 = "{:.2f}".format(F2)
-            self.f2_table.setItem(row, 0, QTableWidgetItem(hkl[0]))
-            self.f2_table.setItem(row, 1, QTableWidgetItem(hkl[1]))
-            self.f2_table.setItem(row, 2, QTableWidgetItem(hkl[2]))
-            self.f2_table.setItem(row, 3, QTableWidgetItem(d))
-            self.f2_table.setItem(row, 4, QTableWidgetItem(F2))
-
-    def set_equivalents(self, result):
-        (hkls, d, F2) = result
-
-        self.f2_table.setRowCount(0)
-        self.f2_table.setRowCount(len(hkls))
-
-        d = "{:.4f}".format(d)
-        F2 = "{:.2f}".format(F2)
-
-        for row, hkl in enumerate(hkls):
-            hkl = ["{:.0f}".format(val) for val in hkl]
+        for row, factor in enumerate(factors):
+            hkl = ["{:.0f}".format(val) for val in [factor["h"], factor["k"], factor["l"]]]
+            d = "{:.4f}".format(factor["d"])
+            F2 = "{:.2f}".format(factor["F²"])
             self.f2_table.setItem(row, 0, QTableWidgetItem(hkl[0]))
             self.f2_table.setItem(row, 1, QTableWidgetItem(hkl[1]))
             self.f2_table.setItem(row, 2, QTableWidgetItem(hkl[2]))

--- a/src/NeuXtalViz/qt/new_views/crystal_structure_tools.py
+++ b/src/NeuXtalViz/qt/new_views/crystal_structure_tools.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from PyQt5.QtWidgets import QFrame, QApplication
+from PyQt5.QtWidgets import QFrame
 from nova.mvvm.pydantic_utils import validate_pydantic_parameter
 from pyvistaqt import QtInteractor
 from qtpy.QtGui import QDoubleValidator
@@ -23,7 +23,7 @@ from qtpy.QtWidgets import (
 from NeuXtalViz.components.visualization_panel.view_qt import VisPanelWidget
 from NeuXtalViz.qt.new_views.periodic_table import PeriodicTableView
 from NeuXtalViz.view_models.crystal_structure_tools import CrystalStructureViewModel, CrystalStructureControls, \
-    CrystalStructureAtoms, CrystalStructureScatterers, SelectedAtom
+    CrystalStructureAtoms, CrystalStructureScatterers
 from NeuXtalViz.views.shared.crystal_structure_plotter import CrystalStructurePlotter
 
 
@@ -47,6 +47,8 @@ class CrystalStructureView(QWidget):
         self.vis_widget = VisPanelWidget("cs", plotter, view_model.model, parent)
         self.view_model.set_vis_viewmodel(self.vis_widget.view_model)
         self.plotter = CrystalStructurePlotter(plotter, self.highlight)
+
+        self.callback_cif = self.view_model.cs_cis_file_bind.connect("cs_cif_file", lambda *args: None)
 
         self.callback_controls = self.view_model.cs_controls_bind.connect("cs_controls", self.on_controls_update)
         self.view_model.cs_scatterers_bind.connect("cs_scatterers", self.on_scatterers_update)
@@ -352,7 +354,7 @@ class CrystalStructureView(QWidget):
 
     def load_CIF(self):
         filename = self.load_CIF_file_dialog()
-        self.view_model.load_CIF(filename)
+        self.callback_cif("cs_cif_file.path", filename or "")
 
     def save_INS(self):
         if self.view_model.save_ins_enabled():
@@ -541,7 +543,6 @@ class CrystalStructureView(QWidget):
                 self.atm_button.text(),
                 *[float(param.text()) for param in params],
             ]
-
 
     def set_formula_z(self, chemical_formula, z_parameter):
         self.chem_line.setText(chemical_formula)

--- a/src/NeuXtalViz/qt/new_views/periodic_table.py
+++ b/src/NeuXtalViz/qt/new_views/periodic_table.py
@@ -79,7 +79,7 @@ class PeriodicTableView(QWidget):
         return table
 
     def on_show_request(self, params: PeriodicTableParams):
-        if params.show:
+        if params.show_dialog:
             self.show()
         else:
             self.close()

--- a/src/NeuXtalViz/qt/views/base_view.py
+++ b/src/NeuXtalViz/qt/views/base_view.py
@@ -597,7 +597,7 @@ class NeuXtalVizWidget(QWidget):
 
         if len(vecs) == 2:
             vec = np.cross(vecs[0], vecs[1])
-            self.plotter.view_vector(vecs[0], vec)
+            self.pv_plotter.view_vector(vecs[0], vec)
         else:
             self.plotter.view_vector(vecs)
 

--- a/src/NeuXtalViz/trame/gui.py
+++ b/src/NeuXtalViz/trame/gui.py
@@ -16,4 +16,4 @@ def trame(server: Server = None, *args: Any, **kwargs: Any) -> None:
             kwargs[key] = int(value)
         except Exception:
             pass
-    app.server.start(**kwargs, host="0.0.0.0", open_browser=True, port=8080, timeout=0)
+    app.server.start(**kwargs, host="0.0.0.0", port=8080, timeout=0)

--- a/src/NeuXtalViz/trame/gui.py
+++ b/src/NeuXtalViz/trame/gui.py
@@ -16,4 +16,4 @@ def trame(server: Server = None, *args: Any, **kwargs: Any) -> None:
             kwargs[key] = int(value)
         except Exception:
             pass
-    app.server.start(**kwargs, host="0.0.0.0", open_browser=False, port=8080, timeout=0)
+    app.server.start(**kwargs, host="0.0.0.0", open_browser=True, port=8080, timeout=0)

--- a/src/NeuXtalViz/trame/views/atom.py
+++ b/src/NeuXtalViz/trame/views/atom.py
@@ -1,6 +1,6 @@
 from nova.mvvm.trame_binding import TrameBinding
 from nova.trame.view.components import InputField
-from nova.trame.view.layouts import HBoxLayout, VBoxLayout
+from nova.trame.view.layouts import GridLayout, HBoxLayout, VBoxLayout
 from trame.widgets import vuetify3 as vuetify
 
 from NeuXtalViz.view_models.atom import AtomViewModel
@@ -17,27 +17,53 @@ class AtomView:
         self.create_ui()
 
     def create_ui(self):
-        with vuetify.VDialog(v_model="atoms.show_dialog", width="500px", update_modelValue="flushState('atoms')"):
-            with vuetify.VCard():
-                with vuetify.VBtn(icon=True, click="atoms.show_dialog = False;flushState('atoms')"):
-                    vuetify.VIcon("mdi-close")
+        with vuetify.VDialog(
+            v_model="atoms.show_dialog",
+            width=400,
+            update_modelValue="flushState('atoms')",
+        ):
+            with vuetify.VCard(classes="pa-2", width="100%"):
                 with HBoxLayout():
-                    InputField("atoms.atom_dict['z']", readonly=True)
-                    InputField(v_model="atoms.current_isotope", items="atoms.isotope_numbers", type="select")
-                    InputField("atoms.atom_dict['abundance']", readonly=True)
+                    vuetify.VBtn(
+                        "Close",
+                        classes="ma-2",
+                        click="atoms.show_dialog = False; flushState('atoms')",
+                    )
+                with HBoxLayout(valign="center"):
+                    vuetify.VLabel(text=("atoms.atom_dict['z']",))
+                    InputField(
+                        v_model="atoms.current_isotope",
+                        items="atoms.isotope_numbers",
+                        type="select",
+                        variant="outlined",  # Not sure why this is necessary here.
+                    )
+                    vuetify.VLabel(
+                        text=("atoms.atom_dict['abundance']",), classes="mr-4"
+                    )
                     vuetify.VBtn("Use Isotope", click=self.view_model.use_isotope)
-                with HBoxLayout():
-                    # if I remove widths, it is a mess
-                    with VBoxLayout(width=600):
-                        InputField("atoms.symbol", readonly=True)
-                        InputField("atoms.name", readonly=True)
-                        InputField("atoms.atom_dict['mass']", readonly=True)
-                    with VBoxLayout(width=600):
-                        InputField("atoms.neutron_dict['sigma_tot']", readonly=True)
-                        InputField("atoms.neutron_dict['sigma_coh']", readonly=True)
-                        InputField("atoms.neutron_dict['sigma_inc']", readonly=True)
-                    with VBoxLayout(width=600):
-                        vuetify.VLabel(text=(
-                        "String(atoms.neutron_dict['b_coh_re']) + '+' + String(atoms.neutron_dict['b_coh_im']) + 'i'",))
-                        vuetify.VLabel(text=(
-                        "String(atoms.neutron_dict['b_inc_re']) + '+' + String(atoms.neutron_dict['b_inc_im']) + 'i'",))
+                with GridLayout(
+                    columns=3, height=100, halign="center", valign="center"
+                ):
+                    vuetify.VLabel(text=("atoms.symbol",))
+                    vuetify.VLabel(
+                        text=("`&sigma;(tot) = ${atoms.neutron_dict['sigma_tot']}`",)
+                    )
+                    vuetify.VSpacer()
+                    vuetify.VLabel(text=("atoms.name",))
+                    vuetify.VLabel(
+                        text=("`&sigma;(coh) = ${atoms.neutron_dict['sigma_coh']}`",)
+                    )
+                    vuetify.VLabel(
+                        text=(
+                            "'b(coh) =' + String(atoms.neutron_dict['b_coh_re']) + '+' + String(atoms.neutron_dict['b_coh_im']) + 'i'",
+                        )
+                    )
+                    vuetify.VLabel(text=("atoms.atom_dict['mass']",))
+                    vuetify.VLabel(
+                        text=("`&sigma;(inc) = ${atoms.neutron_dict['sigma_inc']}`",),
+                    )
+                    vuetify.VLabel(
+                        text=(
+                            "'b(inc) =' + String(atoms.neutron_dict['b_inc_re']) + '+' + String(atoms.neutron_dict['b_inc_im']) + 'i'",
+                        )
+                    )

--- a/src/NeuXtalViz/trame/views/atom.py
+++ b/src/NeuXtalViz/trame/views/atom.py
@@ -1,0 +1,43 @@
+from nova.mvvm.trame_binding import TrameBinding
+from nova.trame.view.components import InputField
+from nova.trame.view.layouts import HBoxLayout, VBoxLayout
+from trame.widgets import vuetify3 as vuetify
+
+from NeuXtalViz.view_models.atom import AtomViewModel
+from NeuXtalViz.view_models.periodic_table import PeriodicTableViewModel
+
+
+class AtomView:
+    def __init__(self, server, pt_view_model: PeriodicTableViewModel):
+        self.server = server
+        binding = TrameBinding(self.server.state)
+        self.view_model = AtomViewModel(binding, pt_view_model)
+        pt_view_model.set_atom_viewmodel(self.view_model)
+        self.view_model.atom_params_bind.connect("atoms")
+        self.create_ui()
+
+    def create_ui(self):
+        with vuetify.VDialog(v_model="atoms.show_dialog", width="500px", update_modelValue="flushState('atoms')"):
+            with vuetify.VCard():
+                with vuetify.VBtn(icon=True, click="atoms.show_dialog = False;flushState('atoms')"):
+                    vuetify.VIcon("mdi-close")
+                with HBoxLayout():
+                    InputField("atoms.atom_dict['z']", readonly=True)
+                    InputField(v_model="atoms.current_isotope", items="atoms.isotope_numbers", type="select")
+                    InputField("atoms.atom_dict['abundance']", readonly=True)
+                    vuetify.VBtn("Use Isotope", click=self.view_model.use_isotope)
+                with HBoxLayout():
+                    # if I remove widths, it is a mess
+                    with VBoxLayout(width=600):
+                        InputField("atoms.symbol", readonly=True)
+                        InputField("atoms.name", readonly=True)
+                        InputField("atoms.atom_dict['mass']", readonly=True)
+                    with VBoxLayout(width=600):
+                        InputField("atoms.neutron_dict['sigma_tot']", readonly=True)
+                        InputField("atoms.neutron_dict['sigma_coh']", readonly=True)
+                        InputField("atoms.neutron_dict['sigma_inc']", readonly=True)
+                    with VBoxLayout(width=600):
+                        vuetify.VLabel(text=(
+                        "String(atoms.neutron_dict['b_coh_re']) + '+' + String(atoms.neutron_dict['b_coh_im']) + 'i'",))
+                        vuetify.VLabel(text=(
+                        "String(atoms.neutron_dict['b_inc_re']) + '+' + String(atoms.neutron_dict['b_inc_im']) + 'i'",))

--- a/src/NeuXtalViz/trame/views/atom.py
+++ b/src/NeuXtalViz/trame/views/atom.py
@@ -23,7 +23,7 @@ class AtomView:
             update_modelValue="flushState('atoms')",
         ):
             with vuetify.VCard(classes="pa-2", width="100%"):
-                with HBoxLayout():
+                with HBoxLayout(halign="right"):
                     vuetify.VBtn(
                         "Close",
                         classes="ma-2",
@@ -35,7 +35,7 @@ class AtomView:
                         v_model="atoms.current_isotope",
                         items="atoms.isotope_numbers",
                         type="select",
-                        variant="outlined",  # Not sure why this is necessary here.
+                        variant="outlined",
                     )
                     vuetify.VLabel(
                         text=("atoms.atom_dict['abundance']",), classes="mr-4"

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -1,8 +1,9 @@
 import pyvista as pv
-from nova.trame.view.layouts import GridLayout
+from nova.trame.view.components import InputField, RemoteFileInput
+from nova.trame.view.layouts import GridLayout, VBoxLayout, HBoxLayout
 
 from NeuXtalViz.components.visualization_panel.view_trame import VisualizationPanel
-from NeuXtalViz.view_models.crystal_structure_tools import CrystalStructureViewModel
+from NeuXtalViz.view_models.crystal_structure_tools import CrystalStructureViewModel, CrystalStructureAtoms
 from NeuXtalViz.views.shared.crystal_structure_plotter import CrystalStructurePlotter
 
 
@@ -10,12 +11,23 @@ class CrystalStructureView:
     def __init__(self, server, view_model: CrystalStructureViewModel):
         self.server = server
         self.view_model = view_model
+        self.view_model.cs_controls_bind.connect("cs_controls")
+        self.view_model.cs_cis_file_bind.connect("cs_cif_file")
+        self.view_model.cs_atoms_bind.connect(self.on_atoms_update)
+        self.view_model.cs_factors_bind.connect("cs_factors")
+        self.view_model.cs_equivalents_bind.connect("cs_equivalents")
+        self.view_model.cs_scatterers_bind.connect("cs_scatterers")
 
         plotter = pv.Plotter(off_screen=True)
         plotter.background_color = "#f0f0f0"
         self.plotter = CrystalStructurePlotter(plotter, self.highlight_row)
 
         self.create_ui()
+
+    def on_atoms_update(self, atoms: CrystalStructureAtoms):
+        self.plotter.add_atoms(atoms.atoms_dict)
+        self.plotter.draw_cell(atoms.cell)
+
 
     def highlight_row(self):
         pass
@@ -31,9 +43,16 @@ class CrystalStructureView:
                                                           self.view_model.model,
                                                           self.server)
             self.view_model.set_vis_viewmodel(self.visualization_panel.view_model)
-            cube = pv.Cube()
-            self.plotter.pv_plotter.add_mesh(cube, color='skyblue', show_edges=True)
-
-#            with VBoxLayout():
-#               with HBoxLayout(valign="center"):
-#                   InputField(v_model="vs_controls.vol_scale", type="select")
+            with VBoxLayout():
+                with HBoxLayout(valign="center"):
+                    InputField(v_model="cs_controls.crystal_system", readonly=True, type="select")
+                    InputField(v_model="cs_controls.space_group", items="cs_controls.space_group_options",
+                               readonly=True, type="select")
+                    InputField(v_model="cs_controls.setting", items="cs_controls.setting_options", readonly=True,
+                               type="select")
+                    RemoteFileInput(
+                        v_model="cs_cif_file.path",
+                        base_paths=["/Users/35y/projects/ndip/tool-sources/NeuXtalViz/tests/data", "/HFIR", "/SNS"],
+                        extensions=["cif"],
+                        input_props={"label": "Load CIF"},
+                    )

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -124,6 +124,10 @@ class StructureTab:
                 items_per_page=-1,
                 item_value="index",
                 select_strategy="single",
+                show_select=True,
+                raw_attrs=[
+                    '@click:row="(_, {internalItem, toggleSelect}) => toggleSelect(internalItem)"'
+                ],
                 update_modelValue="flushState('cs_controls')",
             )
         with HBoxLayout(valign="center"):

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -10,12 +10,17 @@ from trame.widgets import vuetify3 as vuetify
 
 from NeuXtalViz.components.visualization_panel.view_trame import VisualizationPanel
 from NeuXtalViz.trame.views.periodic_table import PeriodicTableView
-from NeuXtalViz.view_models.crystal_structure_tools import CrystalStructureViewModel, CrystalStructureAtoms
+from NeuXtalViz.view_models.crystal_structure_tools import (
+    CrystalStructureViewModel,
+    CrystalStructureAtoms,
+)
 from NeuXtalViz.views.shared.crystal_structure_plotter import CrystalStructurePlotter
 
 
 class StructureTab:
-    def __init__(self, server, view_model: CrystalStructureViewModel, pv_plotter: Plotter):
+    def __init__(
+        self, server, view_model: CrystalStructureViewModel, pv_plotter: Plotter
+    ):
         self.server = server
         self.view_model = view_model
         self.view_model.cs_controls_bind.connect("cs_controls")
@@ -48,51 +53,85 @@ class StructureTab:
 
     def create_ui(self):
         with HBoxLayout(valign="center"):
-            InputField(v_model="cs_controls.crystal_system", disabled=True, type="select")
-            InputField(v_model="cs_controls.space_group", items="cs_controls.space_group_options",
-                       disabled=True, type="select")
-            InputField(v_model="cs_controls.setting", items="cs_controls.setting_options", disabled=True,
-                       type="select")
+            InputField(
+                v_model="cs_controls.crystal_system", disabled=True, type="select"
+            )
+            InputField(
+                v_model="cs_controls.space_group",
+                items="cs_controls.space_group_options",
+                disabled=True,
+                type="select",
+            )
+            InputField(
+                v_model="cs_controls.setting",
+                items="cs_controls.setting_options",
+                disabled=True,
+                type="select",
+            )
             RemoteFileInput(
                 v_model="cs_cif_file.path",
-                base_paths=["/Users/35y/projects/ndip/tool-sources/NeuXtalViz/tests/data", "/HFIR", "/SNS"],
+                base_paths=[
+                    "/Users/qid/Projects/NeuXtalViz/tests/data",
+                    "/HFIR",
+                    "/SNS",
+                ],
                 extensions=["cif"],
                 input_props={"label": "CIF File"},
             )
             vuetify.VBtn("Save INS", click=self.save_ins)
         with HBoxLayout(valign="center"):
-            InputField(v_model="cs_controls.lattice_constants.a",
-                       debounce=100,
-                       disabled=("cs_controls.constrain_parameters[0]",))
-            InputField(v_model="cs_controls.lattice_constants.b",
-                       debounce=100,
-                       disabled=("cs_controls.constrain_parameters[1]",))
-            InputField(v_model="cs_controls.lattice_constants.c",
-                       debounce=100,
-                       disabled=("cs_controls.constrain_parameters[2]",))
-        with HBoxLayout(valign="center"):
-            InputField(v_model="cs_controls.lattice_constants.alpha",
-                       debounce=100,
-                       disabled=("cs_controls.constrain_parameters[3]",))
-            InputField(v_model="cs_controls.lattice_constants.beta",
-                       debounce=100,
-                       disabled=("cs_controls.constrain_parameters[4]",))
-            InputField(v_model="cs_controls.lattice_constants.gamma",
-                       debounce=100,
-                       disabled=("cs_controls.constrain_parameters[5]",))
-        with HBoxLayout(valign="center"):
-            vuetify.VDataTable(
-                v_model="cs_controls.current_scatterer_row",
-                items=("cs_scatterers.scatterer_dict",),
-                item_value='index',
-                headers=("cs_scatterers.scatterer_header",),
-                select_strategy="single",
-                show_select=True,
-                update_modelValue=f"flushState('cs_controls')",
-                disable_sort=True,
+            InputField(
+                v_model="cs_controls.lattice_constants.a",
+                debounce=100,
+                disabled=("cs_controls.constrain_parameters[0]",),
+            )
+            InputField(
+                v_model="cs_controls.lattice_constants.b",
+                debounce=100,
+                disabled=("cs_controls.constrain_parameters[1]",),
+            )
+            InputField(
+                v_model="cs_controls.lattice_constants.c",
+                debounce=100,
+                disabled=("cs_controls.constrain_parameters[2]",),
             )
         with HBoxLayout(valign="center"):
-            vuetify.VBtn(text=("cs_controls.current_scatterer[0]",), width=50, click=self.view_model.select_isotope)
+            InputField(
+                v_model="cs_controls.lattice_constants.alpha",
+                debounce=100,
+                disabled=("cs_controls.constrain_parameters[3]",),
+            )
+            InputField(
+                v_model="cs_controls.lattice_constants.beta",
+                debounce=100,
+                disabled=("cs_controls.constrain_parameters[4]",),
+            )
+            InputField(
+                v_model="cs_controls.lattice_constants.gamma",
+                debounce=100,
+                disabled=("cs_controls.constrain_parameters[5]",),
+            )
+        with HBoxLayout(
+            classes="border-lg border-primary flex-1-1 h-0 overflow-y-auto rounded-sm"
+        ):
+            vuetify.VDataTable(
+                v_model="cs_controls.current_scatterer_row",
+                classes="h-100",
+                disable_sort=True,
+                headers=("cs_scatterers.scatterer_header",),
+                hide_default_footer=True,
+                items=("cs_scatterers.scatterer_dict",),
+                items_per_page=-1,
+                item_value="index",
+                select_strategy="single",
+                update_modelValue="flushState('cs_controls')",
+            )
+        with HBoxLayout(valign="center"):
+            vuetify.VBtn(
+                text=("cs_controls.current_scatterer[0]",),
+                width=50,
+                click=self.view_model.select_isotope,
+            )
             InputField(v_model="cs_controls.current_scatterer[1]")
             InputField(v_model="cs_controls.current_scatterer[2]")
             InputField(v_model="cs_controls.current_scatterer[3]")
@@ -116,12 +155,16 @@ class FactorsTab:
         with HBoxLayout(valign="center"):
             InputField(v_model="cs_controls.minimum_d_spacing")
             vuetify.VBtn("Calculate", click=self.view_model.calculate_F2)
-        with HBoxLayout(valign="center"):
+        with HBoxLayout(
+            classes="border-lg border-primary flex-1-1 h-0 overflow-y-auto rounded-sm"
+        ):
             vuetify.VDataTable(
+                classes="h-100",
+                disable_sort=True,
                 items=("cs_factors.factors_dict",),
+                items_per_page=-1,
                 headers=("cs_factors.factors_header",),
                 show_select=False,
-                disable_sort=True,
             )
         with HBoxLayout(valign="center"):
             InputField(v_model="cs_controls.h")
@@ -142,18 +185,24 @@ class CrystalStructureView:
         self.create_ui()
 
     def create_ui(self):
-        with GridLayout(classes="bg-white pa-2", columns=2):
-            self.visualization_panel = VisualizationPanel("crystal_structure",
-                                                          self.pv_plotter,
-                                                          self.view_model.model,
-                                                          self.server)
+        with GridLayout(classes="bg-white pa-2", columns=2, gap="2em", valign="start"):
+            self.visualization_panel = VisualizationPanel(
+                "crystal_structure", self.pv_plotter, self.view_model.model, self.server
+            )
             self.view_model.set_vis_viewmodel(self.visualization_panel.view_model)
-            with VBoxLayout():
-                with vuetify.VTabs(v_model="structure_active_tab", classes="pl-4", density="compact"):
+            with VBoxLayout(classes="h-100"):
+                with vuetify.VTabs(v_model="structure_active_tab", classes="pl-2"):
                     vuetify.VTab("Structure", value=0)
                     vuetify.VTab("Factors", value=1)
-                with vuetify.VWindow(v_model="structure_active_tab"):
-                    with vuetify.VWindowItem(value=0):
+                with vuetify.VWindow(
+                    v_model="structure_active_tab",
+                    classes="border-sm border-primary h-100 pa-1 rounded",
+                ):
+                    with vuetify.VWindowItem(
+                        classes="flex-column h-100", style="display: flex", value=0
+                    ):
                         StructureTab(self.server, self.view_model, self.pv_plotter)
-                    with vuetify.VWindowItem(value=1):
+                    with vuetify.VWindowItem(
+                        classes="flex-column h-100", style="display: flex", value=1
+                    ):
                         FactorsTab(self.server, self.view_model)

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -16,14 +16,10 @@ from NeuXtalViz.views.shared.crystal_structure_plotter import CrystalStructurePl
 class StructureTab:
     def __init__(self, server, view_model: CrystalStructureViewModel, pv_plotter: Plotter):
         self.server = server
-        self.ctrl = server.controller
-        self.server = server
         self.view_model = view_model
         self.view_model.cs_controls_bind.connect("cs_controls")
         self.view_model.cs_cis_file_bind.connect("cs_cif_file")
         self.view_model.cs_atoms_bind.connect(self.on_atoms_update)
-        self.view_model.cs_factors_bind.connect("cs_factors")
-        self.view_model.cs_equivalents_bind.connect("cs_equivalents")
         self.view_model.cs_scatterers_bind.connect("cs_scatterers")
         self.plotter = CrystalStructurePlotter(pv_plotter, self.highlight_row)
 
@@ -38,10 +34,6 @@ class StructureTab:
 
     def highlight_row(self, row):
         self.view_model.select_row(row)
-
-    @property
-    def state(self):
-        return self.server.state
 
     def save_ins(self):
         if self.view_model.save_ins_enabled():
@@ -111,6 +103,31 @@ class StructureTab:
             InputField(v_model="cs_controls.vol", readonly=True)
 
 
+class FactorsTab:
+    def __init__(self, server, view_model: CrystalStructureViewModel):
+        self.server = server
+        self.view_model = view_model
+        self.view_model.cs_factors_bind.connect("cs_factors")
+        self.create_ui()
+
+    def create_ui(self):
+        with HBoxLayout(valign="center"):
+            InputField(v_model="cs_controls.minimum_d_spacing")
+            vuetify.VBtn("Calculate", click=self.view_model.calculate_F2)
+        with HBoxLayout(valign="center"):
+            vuetify.VDataTable(
+                items=("cs_factors.factors_dict",),
+                headers=("cs_factors.factors_header",),
+                show_select=False,
+                disable_sort=True,
+            )
+        with HBoxLayout(valign="center"):
+            InputField(v_model="cs_controls.h")
+            InputField(v_model="cs_controls.k")
+            InputField(v_model="cs_controls.l")
+            vuetify.VBtn("Calculate", click=self.view_model.calculate_hkl)
+
+
 class CrystalStructureView:
     def __init__(self, server, view_model: CrystalStructureViewModel):
         self.server = server
@@ -137,4 +154,4 @@ class CrystalStructureView:
                     with vuetify.VWindowItem(value=0):
                         StructureTab(self.server, self.view_model, self.pv_plotter)
                     with vuetify.VWindowItem(value=1):
-                        pass
+                        FactorsTab(self.server, self.view_model)

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -106,11 +106,11 @@ class CrystalStructureView:
                         disable_sort=True,
                     )
                 with HBoxLayout(valign="center"):
-                    InputField(v_model="cs_controls.current_scatterer[0]", read_only=True)
-                    InputField(v_model="cs_controls.current_scatterer[1]", read_only=True)
-                    InputField(v_model="cs_controls.current_scatterer[2]", read_only=True)
-                    InputField(v_model="cs_controls.current_scatterer[3]", read_only=True)
-                    InputField(v_model="cs_controls.current_scatterer[4]", read_only=True)
-                    InputField(v_model="cs_controls.current_scatterer[5]", read_only=True)
+                    vuetify.VBtn(text=("cs_controls.current_scatterer[0]",), width=50)
+                    InputField(v_model="cs_controls.current_scatterer[1]")
+                    InputField(v_model="cs_controls.current_scatterer[2]")
+                    InputField(v_model="cs_controls.current_scatterer[3]")
+                    InputField(v_model="cs_controls.current_scatterer[4]")
+                    InputField(v_model="cs_controls.current_scatterer[5]")
 
 

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -4,6 +4,7 @@ import tempfile
 import pyvista as pv
 from nova.trame.view.components import InputField, RemoteFileInput
 from nova.trame.view.layouts import GridLayout, VBoxLayout, HBoxLayout
+from pyvista import Plotter
 from trame.widgets import client
 from trame.widgets import vuetify3 as vuetify
 
@@ -12,10 +13,11 @@ from NeuXtalViz.view_models.crystal_structure_tools import CrystalStructureViewM
 from NeuXtalViz.views.shared.crystal_structure_plotter import CrystalStructurePlotter
 
 
-class CrystalStructureView:
-    def __init__(self, server, view_model: CrystalStructureViewModel):
+class StructureTab:
+    def __init__(self, server, view_model: CrystalStructureViewModel, pv_plotter: Plotter):
         self.server = server
         self.ctrl = server.controller
+        self.server = server
         self.view_model = view_model
         self.view_model.cs_controls_bind.connect("cs_controls")
         self.view_model.cs_cis_file_bind.connect("cs_cif_file")
@@ -23,9 +25,7 @@ class CrystalStructureView:
         self.view_model.cs_factors_bind.connect("cs_factors")
         self.view_model.cs_equivalents_bind.connect("cs_equivalents")
         self.view_model.cs_scatterers_bind.connect("cs_scatterers")
-        plotter = pv.Plotter(off_screen=True)
-        plotter.background_color = "#f0f0f0"
-        self.plotter = CrystalStructurePlotter(plotter, self.highlight_row)
+        self.plotter = CrystalStructurePlotter(pv_plotter, self.highlight_row)
 
         self.js_download = client.JSEval(
             exec="utils.download($event[0], $event[1], 'text/plain')"
@@ -54,63 +54,87 @@ class CrystalStructureView:
             os.remove(path)
 
     def create_ui(self):
+        with HBoxLayout(valign="center"):
+            InputField(v_model="cs_controls.crystal_system", disabled=True, type="select")
+            InputField(v_model="cs_controls.space_group", items="cs_controls.space_group_options",
+                       disabled=True, type="select")
+            InputField(v_model="cs_controls.setting", items="cs_controls.setting_options", disabled=True,
+                       type="select")
+            RemoteFileInput(
+                v_model="cs_cif_file.path",
+                base_paths=["/Users/35y/projects/ndip/tool-sources/NeuXtalViz/tests/data", "/HFIR", "/SNS"],
+                extensions=["cif"],
+                input_props={"label": "CIF File"},
+            )
+            vuetify.VBtn("Save INS", click=self.save_ins)
+        with HBoxLayout(valign="center"):
+            InputField(v_model="cs_controls.lattice_constants.a",
+                       debounce=100,
+                       disabled=("cs_controls.constrain_parameters[0]",))
+            InputField(v_model="cs_controls.lattice_constants.b",
+                       debounce=100,
+                       disabled=("cs_controls.constrain_parameters[1]",))
+            InputField(v_model="cs_controls.lattice_constants.c",
+                       debounce=100,
+                       disabled=("cs_controls.constrain_parameters[2]",))
+        with HBoxLayout(valign="center"):
+            InputField(v_model="cs_controls.lattice_constants.alpha",
+                       debounce=100,
+                       disabled=("cs_controls.constrain_parameters[3]",))
+            InputField(v_model="cs_controls.lattice_constants.beta",
+                       debounce=100,
+                       disabled=("cs_controls.constrain_parameters[4]",))
+            InputField(v_model="cs_controls.lattice_constants.gamma",
+                       debounce=100,
+                       disabled=("cs_controls.constrain_parameters[5]",))
+        with HBoxLayout(valign="center"):
+            vuetify.VDataTable(
+                v_model="cs_controls.current_scatterer_row",
+                items=("cs_scatterers.scatterer_dict",),
+                item_value='index',
+                headers=("cs_scatterers.scatterer_header",),
+                select_strategy="single",
+                show_select=True,
+                update_modelValue=f"flushState('cs_controls')",
+                disable_sort=True,
+            )
+        with HBoxLayout(valign="center"):
+            vuetify.VBtn(text=("cs_controls.current_scatterer[0]",), width=50)
+            InputField(v_model="cs_controls.current_scatterer[1]")
+            InputField(v_model="cs_controls.current_scatterer[2]")
+            InputField(v_model="cs_controls.current_scatterer[3]")
+            InputField(v_model="cs_controls.current_scatterer[4]")
+            InputField(v_model="cs_controls.current_scatterer[5]")
+        with HBoxLayout(valign="center"):
+            InputField(v_model="cs_controls.formula", readonly=True)
+            InputField(v_model="cs_controls.z", readonly=True)
+            InputField(v_model="cs_controls.vol", readonly=True)
+
+
+class CrystalStructureView:
+    def __init__(self, server, view_model: CrystalStructureViewModel):
+        self.server = server
+        self.view_model = view_model
+        self.server.state.structure_active_tab = 0
+        plotter = pv.Plotter(off_screen=True)
+        plotter.background_color = "#f0f0f0"
+        self.pv_plotter = plotter
+
+        self.create_ui()
+
+    def create_ui(self):
         with GridLayout(classes="bg-white pa-2", columns=2):
             self.visualization_panel = VisualizationPanel("crystal_structure",
-                                                          self.plotter.pv_plotter,
+                                                          self.pv_plotter,
                                                           self.view_model.model,
                                                           self.server)
             self.view_model.set_vis_viewmodel(self.visualization_panel.view_model)
             with VBoxLayout():
-                with HBoxLayout(valign="center"):
-                    InputField(v_model="cs_controls.crystal_system", disabled=True, type="select")
-                    InputField(v_model="cs_controls.space_group", items="cs_controls.space_group_options",
-                               disabled=True, type="select")
-                    InputField(v_model="cs_controls.setting", items="cs_controls.setting_options", disabled=True,
-                               type="select")
-                    RemoteFileInput(
-                        v_model="cs_cif_file.path",
-                        base_paths=["/Users/35y/projects/ndip/tool-sources/NeuXtalViz/tests/data", "/HFIR", "/SNS"],
-                        extensions=["cif"],
-                        input_props={"label": "CIF File"},
-                    )
-                    vuetify.VBtn("Save INS", click=self.save_ins)
-                with HBoxLayout(valign="center"):
-                    InputField(v_model="cs_controls.lattice_constants.a",
-                               debounce=100,
-                               disabled=("cs_controls.constrain_parameters[0]",))
-                    InputField(v_model="cs_controls.lattice_constants.b",
-                               debounce=100,
-                               disabled=("cs_controls.constrain_parameters[1]",))
-                    InputField(v_model="cs_controls.lattice_constants.c",
-                               debounce=100,
-                               disabled=("cs_controls.constrain_parameters[2]",))
-                with HBoxLayout(valign="center"):
-                    InputField(v_model="cs_controls.lattice_constants.alpha",
-                               debounce=100,
-                               disabled=("cs_controls.constrain_parameters[3]",))
-                    InputField(v_model="cs_controls.lattice_constants.beta",
-                               debounce=100,
-                               disabled=("cs_controls.constrain_parameters[4]",))
-                    InputField(v_model="cs_controls.lattice_constants.gamma",
-                               debounce=100,
-                               disabled=("cs_controls.constrain_parameters[5]",))
-                with HBoxLayout(valign="center"):
-                    vuetify.VDataTable(
-                        v_model="cs_controls.current_scatterer_row",
-                        items=("cs_scatterers.scatterer_dict",),
-                        item_value='index',
-                        headers=("cs_scatterers.scatterer_header",),
-                        select_strategy="single",
-                        show_select=True,
-                        update_modelValue=f"flushState('cs_controls')",
-                        disable_sort=True,
-                    )
-                with HBoxLayout(valign="center"):
-                    vuetify.VBtn(text=("cs_controls.current_scatterer[0]",), width=50)
-                    InputField(v_model="cs_controls.current_scatterer[1]")
-                    InputField(v_model="cs_controls.current_scatterer[2]")
-                    InputField(v_model="cs_controls.current_scatterer[3]")
-                    InputField(v_model="cs_controls.current_scatterer[4]")
-                    InputField(v_model="cs_controls.current_scatterer[5]")
-
-
+                with vuetify.VTabs(v_model="structure_active_tab", classes="pl-4", density="compact"):
+                    vuetify.VTab("Structure", value=0)
+                    vuetify.VTab("Factors", value=1)
+                with vuetify.VWindow(v_model="structure_active_tab"):
+                    with vuetify.VWindowItem(value=0):
+                        StructureTab(self.server, self.view_model, self.pv_plotter)
+                    with vuetify.VWindowItem(value=1):
+                        pass

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -165,6 +165,7 @@ class FactorsTab:
             vuetify.VDataTable(
                 classes="h-100",
                 disable_sort=True,
+                hide_default_footer=True,
                 items=("cs_factors.factors_dict",),
                 items_per_page=-1,
                 headers=("cs_factors.factors_header",),

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -9,6 +9,7 @@ from trame.widgets import client
 from trame.widgets import vuetify3 as vuetify
 
 from NeuXtalViz.components.visualization_panel.view_trame import VisualizationPanel
+from NeuXtalViz.trame.views.periodic_table import PeriodicTableView
 from NeuXtalViz.view_models.crystal_structure_tools import CrystalStructureViewModel, CrystalStructureAtoms
 from NeuXtalViz.views.shared.crystal_structure_plotter import CrystalStructurePlotter
 
@@ -91,7 +92,7 @@ class StructureTab:
                 disable_sort=True,
             )
         with HBoxLayout(valign="center"):
-            vuetify.VBtn(text=("cs_controls.current_scatterer[0]",), width=50)
+            vuetify.VBtn(text=("cs_controls.current_scatterer[0]",), width=50, click=self.view_model.select_isotope)
             InputField(v_model="cs_controls.current_scatterer[1]")
             InputField(v_model="cs_controls.current_scatterer[2]")
             InputField(v_model="cs_controls.current_scatterer[3]")
@@ -101,6 +102,8 @@ class StructureTab:
             InputField(v_model="cs_controls.formula", readonly=True)
             InputField(v_model="cs_controls.z", readonly=True)
             InputField(v_model="cs_controls.vol", readonly=True)
+        self.periodic_table = PeriodicTableView(self.server, self.view_model)
+        self.view_model.set_perioric_table_viewmodel(self.periodic_table.view_model)
 
 
 class FactorsTab:

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -102,8 +102,7 @@ class StructureTab:
             InputField(v_model="cs_controls.formula", readonly=True)
             InputField(v_model="cs_controls.z", readonly=True)
             InputField(v_model="cs_controls.vol", readonly=True)
-        self.periodic_table = PeriodicTableView(self.server, self.view_model)
-        self.view_model.set_perioric_table_viewmodel(self.periodic_table.view_model)
+        PeriodicTableView(self.server, self.view_model)
 
 
 class FactorsTab:

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -1,0 +1,39 @@
+import pyvista as pv
+from nova.trame.view.layouts import GridLayout
+
+from NeuXtalViz.components.visualization_panel.view_trame import VisualizationPanel
+from NeuXtalViz.view_models.crystal_structure_tools import CrystalStructureViewModel
+from NeuXtalViz.views.shared.crystal_structure_plotter import CrystalStructurePlotter
+
+
+class CrystalStructureView:
+    def __init__(self, server, view_model: CrystalStructureViewModel):
+        self.server = server
+        self.view_model = view_model
+
+        plotter = pv.Plotter(off_screen=True)
+        plotter.background_color = "#f0f0f0"
+        self.plotter = CrystalStructurePlotter(plotter, self.highlight_row)
+
+        self.create_ui()
+
+    def highlight_row(self):
+        pass
+
+    @property
+    def state(self):
+        return self.server.state
+
+    def create_ui(self):
+        with GridLayout(classes="bg-white pa-2", columns=2):
+            self.visualization_panel = VisualizationPanel("crystal_structure",
+                                                          self.plotter.pv_plotter,
+                                                          self.view_model.model,
+                                                          self.server)
+            self.view_model.set_vis_viewmodel(self.visualization_panel.view_model)
+            cube = pv.Cube()
+            self.plotter.pv_plotter.add_mesh(cube, color='skyblue', show_edges=True)
+
+#            with VBoxLayout():
+#               with HBoxLayout(valign="center"):
+#                   InputField(v_model="vs_controls.vol_scale", type="select")

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -1,6 +1,11 @@
+import os
+import tempfile
+
 import pyvista as pv
 from nova.trame.view.components import InputField, RemoteFileInput
 from nova.trame.view.layouts import GridLayout, VBoxLayout, HBoxLayout
+from trame.widgets import client
+from trame.widgets import vuetify3 as vuetify
 
 from NeuXtalViz.components.visualization_panel.view_trame import VisualizationPanel
 from NeuXtalViz.view_models.crystal_structure_tools import CrystalStructureViewModel, CrystalStructureAtoms
@@ -10,6 +15,7 @@ from NeuXtalViz.views.shared.crystal_structure_plotter import CrystalStructurePl
 class CrystalStructureView:
     def __init__(self, server, view_model: CrystalStructureViewModel):
         self.server = server
+        self.ctrl = server.controller
         self.view_model = view_model
         self.view_model.cs_controls_bind.connect("cs_controls")
         self.view_model.cs_cis_file_bind.connect("cs_cif_file")
@@ -17,24 +23,35 @@ class CrystalStructureView:
         self.view_model.cs_factors_bind.connect("cs_factors")
         self.view_model.cs_equivalents_bind.connect("cs_equivalents")
         self.view_model.cs_scatterers_bind.connect("cs_scatterers")
-
         plotter = pv.Plotter(off_screen=True)
         plotter.background_color = "#f0f0f0"
         self.plotter = CrystalStructurePlotter(plotter, self.highlight_row)
 
+        self.js_download = client.JSEval(
+            exec="utils.download($event[0], $event[1], 'text/plain')"
+        ).exec
         self.create_ui()
 
     def on_atoms_update(self, atoms: CrystalStructureAtoms):
         self.plotter.add_atoms(atoms.atoms_dict)
         self.plotter.draw_cell(atoms.cell)
 
-
-    def highlight_row(self):
-        pass
+    def highlight_row(self, row):
+        self.view_model.select_row(row)
 
     @property
     def state(self):
         return self.server.state
+
+    def save_ins(self):
+        if self.view_model.save_ins_enabled():
+            fd, path = tempfile.mkstemp(suffix=".ins")
+            os.close(fd)
+            self.view_model.save_INS(path)
+            with open(path, "rb") as f:
+                data = f.read()
+                self.js_download(("cs.ins", data))
+            os.remove(path)
 
     def create_ui(self):
         with GridLayout(classes="bg-white pa-2", columns=2):
@@ -45,14 +62,55 @@ class CrystalStructureView:
             self.view_model.set_vis_viewmodel(self.visualization_panel.view_model)
             with VBoxLayout():
                 with HBoxLayout(valign="center"):
-                    InputField(v_model="cs_controls.crystal_system", readonly=True, type="select")
+                    InputField(v_model="cs_controls.crystal_system", disabled=True, type="select")
                     InputField(v_model="cs_controls.space_group", items="cs_controls.space_group_options",
-                               readonly=True, type="select")
-                    InputField(v_model="cs_controls.setting", items="cs_controls.setting_options", readonly=True,
+                               disabled=True, type="select")
+                    InputField(v_model="cs_controls.setting", items="cs_controls.setting_options", disabled=True,
                                type="select")
                     RemoteFileInput(
                         v_model="cs_cif_file.path",
                         base_paths=["/Users/35y/projects/ndip/tool-sources/NeuXtalViz/tests/data", "/HFIR", "/SNS"],
                         extensions=["cif"],
-                        input_props={"label": "Load CIF"},
+                        input_props={"label": "CIF File"},
                     )
+                    vuetify.VBtn("Save INS", click=self.save_ins)
+                with HBoxLayout(valign="center"):
+                    InputField(v_model="cs_controls.lattice_constants.a",
+                               debounce=100,
+                               disabled=("cs_controls.constrain_parameters[0]",))
+                    InputField(v_model="cs_controls.lattice_constants.b",
+                               debounce=100,
+                               disabled=("cs_controls.constrain_parameters[1]",))
+                    InputField(v_model="cs_controls.lattice_constants.c",
+                               debounce=100,
+                               disabled=("cs_controls.constrain_parameters[2]",))
+                with HBoxLayout(valign="center"):
+                    InputField(v_model="cs_controls.lattice_constants.alpha",
+                               debounce=100,
+                               disabled=("cs_controls.constrain_parameters[3]",))
+                    InputField(v_model="cs_controls.lattice_constants.beta",
+                               debounce=100,
+                               disabled=("cs_controls.constrain_parameters[4]",))
+                    InputField(v_model="cs_controls.lattice_constants.gamma",
+                               debounce=100,
+                               disabled=("cs_controls.constrain_parameters[5]",))
+                with HBoxLayout(valign="center"):
+                    vuetify.VDataTable(
+                        v_model="cs_controls.current_scatterer_row",
+                        items=("cs_scatterers.scatterer_dict",),
+                        item_value='index',
+                        headers=("cs_scatterers.scatterer_header",),
+                        select_strategy="single",
+                        show_select=True,
+                        update_modelValue=f"flushState('cs_controls')",
+                        disable_sort=True,
+                    )
+                with HBoxLayout(valign="center"):
+                    InputField(v_model="cs_controls.current_scatterer[0]", read_only=True)
+                    InputField(v_model="cs_controls.current_scatterer[1]", read_only=True)
+                    InputField(v_model="cs_controls.current_scatterer[2]", read_only=True)
+                    InputField(v_model="cs_controls.current_scatterer[3]", read_only=True)
+                    InputField(v_model="cs_controls.current_scatterer[4]", read_only=True)
+                    InputField(v_model="cs_controls.current_scatterer[5]", read_only=True)
+
+

--- a/src/NeuXtalViz/trame/views/crystal_structure.py
+++ b/src/NeuXtalViz/trame/views/crystal_structure.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 
 import pyvista as pv
-from nova.trame.view.components import InputField, RemoteFileInput
+from nova.trame.view.components import FileUpload, InputField
 from nova.trame.view.layouts import GridLayout, VBoxLayout, HBoxLayout
 from pyvista import Plotter
 from trame.widgets import client
@@ -68,15 +68,13 @@ class StructureTab:
                 disabled=True,
                 type="select",
             )
-            RemoteFileInput(
+            FileUpload(
                 v_model="cs_cif_file.path",
-                base_paths=[
-                    "/Users/qid/Projects/NeuXtalViz/tests/data",
-                    "/HFIR",
-                    "/SNS",
-                ],
+                base_paths=["/HFIR", "/SNS"],
+                classes="mr-1",
                 extensions=["cif"],
-                input_props={"label": "CIF File"},
+                label="Load CIF",
+                return_contents=False,
             )
             vuetify.VBtn("Save INS", click=self.save_ins)
         with HBoxLayout(valign="center"):

--- a/src/NeuXtalViz/trame/views/main_view.py
+++ b/src/NeuXtalViz/trame/views/main_view.py
@@ -23,8 +23,12 @@ class NeuXtalViz(ThemedApp):
 
         binding = TrameBinding(self.server.state)
 
-        self.volume_slicer_view_model = VolumeSlicerViewModel(VolumeSlicerModel(), binding)
-        self.crystal_structure_view_model = CrystalStructureViewModel(CrystalStructureModel(), binding)
+        self.crystal_structure_view_model = CrystalStructureViewModel(
+            CrystalStructureModel(), binding
+        )
+        self.volume_slicer_view_model = VolumeSlicerViewModel(
+            VolumeSlicerModel(), binding
+        )
 
         self.create_ui()
 
@@ -35,18 +39,19 @@ class NeuXtalViz(ThemedApp):
     def create_ui(self) -> None:
         self.state.trame__title = "NeuXtalViz"
         self.set_theme("CompactTheme")
-        self.state.active_app = 1
+        self.state.active_app = 0
         with super().create_ui() as layout:
             layout.toolbar_title.set_text("NeuXtalViz")
 
             with layout.pre_content:
-                with vuetify.VTabs(v_model="active_app", classes="pl-4", density="compact"):
+                with vuetify.VTabs(v_model="active_app", classes="pl-6"):
+                    vuetify.VTab("Crystal Structure", value=0)
                     vuetify.VTab("Volume Slicer", value=1)
-                    vuetify.VTab("Crystal Structure", value=2)
             with layout.content:
                 with vuetify.VWindow(v_model="active_app"):
+                    with vuetify.VWindowItem(value=0):
+                        CrystalStructureView(
+                            self.server, self.crystal_structure_view_model
+                        )
                     with vuetify.VWindowItem(value=1):
                         VolumeSlicerView(self.server, self.volume_slicer_view_model)
-                    with vuetify.VWindowItem(value=2):
-                        CrystalStructureView(self.server, self.crystal_structure_view_model)
-

--- a/src/NeuXtalViz/trame/views/main_view.py
+++ b/src/NeuXtalViz/trame/views/main_view.py
@@ -45,7 +45,6 @@ class NeuXtalViz(ThemedApp):
                     vuetify.VTab("Crystal Structure", value=2)
             with layout.content:
                 with vuetify.VWindow(v_model="active_app"):
-                    pass
                     with vuetify.VWindowItem(value=1):
                         VolumeSlicerView(self.server, self.volume_slicer_view_model)
                     with vuetify.VWindowItem(value=2):

--- a/src/NeuXtalViz/trame/views/main_view.py
+++ b/src/NeuXtalViz/trame/views/main_view.py
@@ -6,8 +6,11 @@ from trame.widgets import vuetify3 as vuetify
 from trame_server.core import Server
 from trame_server.state import State
 
+from NeuXtalViz.models.crystal_structure_tools import CrystalStructureModel
 from NeuXtalViz.models.volume_slicer import VolumeSlicerModel
+from NeuXtalViz.trame.views.crystal_structure import CrystalStructureView
 from NeuXtalViz.trame.views.volume_slicer import VolumeSlicerView
+from NeuXtalViz.view_models.crystal_structure_tools import CrystalStructureViewModel
 from NeuXtalViz.view_models.volume_slicer import VolumeSlicerViewModel
 
 
@@ -20,7 +23,8 @@ class NeuXtalViz(ThemedApp):
 
         binding = TrameBinding(self.server.state)
 
-        self.view_model = VolumeSlicerViewModel(VolumeSlicerModel(), binding)
+        self.volume_slicer_view_model = VolumeSlicerViewModel(VolumeSlicerModel(), binding)
+        self.crystal_structure_view_model = CrystalStructureViewModel(CrystalStructureModel(), binding)
 
         self.create_ui()
 
@@ -31,13 +35,19 @@ class NeuXtalViz(ThemedApp):
     def create_ui(self) -> None:
         self.state.trame__title = "NeuXtalViz"
         self.set_theme("CompactTheme")
-
+        self.state.active_app = 1
         with super().create_ui() as layout:
             layout.toolbar_title.set_text("NeuXtalViz")
 
             with layout.pre_content:
-                with vuetify.VTabs(classes="pl-4", density="compact"):
-                    vuetify.VTab("Volume Slicer")
-
+                with vuetify.VTabs(v_model="active_app", classes="pl-4", density="compact"):
+                    vuetify.VTab("Volume Slicer", value=1)
+                    vuetify.VTab("Crystal Structure", value=2)
             with layout.content:
-                VolumeSlicerView(self.server, self.view_model)
+                with vuetify.VWindow(v_model="active_app"):
+                    pass
+                    with vuetify.VWindowItem(value=1):
+                        VolumeSlicerView(self.server, self.volume_slicer_view_model)
+                    with vuetify.VWindowItem(value=2):
+                        CrystalStructureView(self.server, self.crystal_structure_view_model)
+

--- a/src/NeuXtalViz/trame/views/periodic_table.py
+++ b/src/NeuXtalViz/trame/views/periodic_table.py
@@ -62,7 +62,6 @@ class PeriodicTableView:
                                 group = groups.get(key)
                                 bg_color = colors[group]
                                 disabled = isotopes.get(key) is None
-                                # ??? setting color changes background color, we only want to set text color
                                 (
                                     vuetify.VBtn(
                                         key,

--- a/src/NeuXtalViz/trame/views/periodic_table.py
+++ b/src/NeuXtalViz/trame/views/periodic_table.py
@@ -49,7 +49,7 @@ class PeriodicTableView:
             update_modelValue="flushState('pt_model')",
         ):
             with vuetify.VCard(classes="text-center"):
-                with HBoxLayout(classes="ma-2"):
+                with HBoxLayout(classes="ma-2",halign="right"):
                     vuetify.VBtn(
                         "Close",
                         click="pt_model.show_dialog = False; flushState('pt_model')",

--- a/src/NeuXtalViz/trame/views/periodic_table.py
+++ b/src/NeuXtalViz/trame/views/periodic_table.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from nova.mvvm.trame_binding import TrameBinding
-from nova.trame.view.layouts import GridLayout
+from nova.trame.view.layouts import GridLayout, HBoxLayout
 from trame.widgets import vuetify3 as vuetify
 
 from NeuXtalViz.config.atoms import indexing, groups, isotopes
@@ -43,11 +43,17 @@ class PeriodicTableView:
             grid.setdefault(row, {})[col] = key
             max_col = max(max_col, col)
 
-        with vuetify.VDialog(v_model="pt_model.show_dialog", width="auto", update_modelValue="flushState('pt_model')"):
-            with vuetify.VBtn(icon=True, click="pt_model.show_dialog = False;flushState('pt_model')"):
-                vuetify.VIcon("mdi-close")
-
+        with vuetify.VDialog(
+            v_model="pt_model.show_dialog",
+            width="auto",
+            update_modelValue="flushState('pt_model')",
+        ):
             with vuetify.VCard(classes="text-center"):
+                with HBoxLayout(classes="ma-2"):
+                    vuetify.VBtn(
+                        "Close",
+                        click="pt_model.show_dialog = False; flushState('pt_model')",
+                    )
                 with GridLayout(columns=max_col):
                     for row_idx in sorted(grid.keys()):
                         for col_idx in range(max_col):
@@ -56,16 +62,17 @@ class PeriodicTableView:
                                 group = groups.get(key)
                                 bg_color = colors[group]
                                 disabled = isotopes.get(key) is None
-                                text_color = "primary"
-                                if disabled:
-                                    text_color = "grey"
                                 # ??? setting color changes background color, we only want to set text color
-                                vuetify.VBtn(
-                                    key,
-                                    style=f"background-color: {bg_color} !important; width: 50px; height: 50px;",
-                                    classes=f"ma-1",
-                                    disabled=disabled,
-                                    click=partial(self.atom_clicked, key)),
+                                (
+                                    vuetify.VBtn(
+                                        key,
+                                        classes="ma-1",
+                                        color=bg_color if not disabled else "lightgrey",
+                                        disabled=disabled,
+                                        style="height: 50px; width: 50px;",
+                                        click=partial(self.atom_clicked, key),
+                                    ),
+                                )
                             else:
                                 vuetify.VSheet()
 

--- a/src/NeuXtalViz/trame/views/periodic_table.py
+++ b/src/NeuXtalViz/trame/views/periodic_table.py
@@ -1,0 +1,60 @@
+from functools import partial
+
+from nova.mvvm.trame_binding import TrameBinding
+from trame.widgets import vuetify3 as vuetify
+
+from NeuXtalViz.config.atoms import indexing, groups, isotopes
+from NeuXtalViz.view_models.crystal_structure_tools import CrystalStructureViewModel
+from NeuXtalViz.view_models.periodic_table import PeriodicTableViewModel
+
+colors = {
+    "Transition Metals": "#A1C9F4",  # blue
+    "Alkaline Earth Metals": "#FFB482",  # orange
+    "Nonmetals": "#8DE5A1",  # green
+    "Alkali Metals": "#FF9F9B",  # red
+    "Lanthanides": "#D0BBFF",  # purple
+    "Metalloids": "#DEBB9B",  # brown
+    "Actinides": "#FAB0E4",  # pink
+    "Other Metals": "#CFCFCF",  # gray
+    "Halogens": "#FFFEA3",  # yellow
+    "Noble Gases": "#B9F2F0",
+}  # cyan
+
+
+class PeriodicTableView:
+    def __init__(self, server, crystal_view_model: CrystalStructureViewModel):
+        self.server = server
+        binding = TrameBinding(self.server.state)
+        self.view_model = PeriodicTableViewModel(binding, crystal_view_model)
+        self.view_model.pt_model_bind.connect("pt_model")
+        self.create_ui()
+
+    def atom_clicked(self, key: str):
+        print(key)
+
+    def create_ui(self):
+        grid = {}
+        for key, (row, col) in indexing.items():
+            grid.setdefault(row, {})[col] = key
+
+        with vuetify.VDialog(v_model="pt_model.show", width="auto", update_modelValue="flushState('pt_model')"):
+            with vuetify.VCard(classes="text-center"):
+                for row_idx in sorted(grid.keys()):
+                    with vuetify.VRow(no_gutters=True):
+                        for col_idx in range(max(grid[row_idx].keys()) + 1):
+                            key = grid[row_idx].get(col_idx)
+                            if key:
+                                group = groups.get(key)
+                                color = colors.get(group, "white")
+                                disabled = isotopes.get(key) is None
+                                with vuetify.VCol(cols="auto"):
+                                    vuetify.VBtn(
+                                        key,
+                                        style=f"background-color: {color} !important; min-width: 50px; min-height: 50px;",
+                                        disabled=disabled,
+                                        click=partial(self.atom_clicked, key)),
+                            else:
+                                vuetify.VCol(cols="auto")  # empty spacer
+
+            with vuetify.VBtn(icon=True, click="pt_model.show = False;flushState('pt_model')"):
+                vuetify.VIcon("mdi-close")

--- a/src/NeuXtalViz/view_models/atom.py
+++ b/src/NeuXtalViz/view_models/atom.py
@@ -13,7 +13,8 @@ class AtomParams(BaseModel):
     current_isotope: int = 0
     atom_dict: Dict[str, Any] = {}
     neutron_dict: Dict[str, Any] = {}
-    view_dialog: bool = False
+    show_dialog: bool = False
+
 
 class AtomViewModel:
     def __init__(self, binding, periodic_table_view_model: PeriodicTableViewModel):
@@ -33,10 +34,8 @@ class AtomViewModel:
         self.atom_params.symbol, self.atom_params.name = self.atom_model.get_symbol_name()
         self.atom_params.isotope_numbers = self.atom_model.get_isotope_numbers()
         if reset_isotope:
-            self.atom_params.current_isotope = 0
-        isotope = 0
-        if self.atom_params.current_isotope < len(self.atom_params.isotope_numbers):
-            isotope = self.atom_params.isotope_numbers[self.atom_params.current_isotope]
+            self.atom_params.current_isotope = self.atom_params.isotope_numbers[0] if self.atom_params.isotope_numbers else 0
+        isotope = self.atom_params.current_isotope
         self.atom_model.generate_data(isotope)
         self.atom_params.atom_dict = self.atom_model.atom_dict
         self.atom_params.neutron_dict = self.atom_model.neutron_dict
@@ -44,10 +43,10 @@ class AtomViewModel:
     def show_dialog(self, atom):
         self.atom_model = AtomModel(atom)
         self.update_params_from_model(reset_isotope=True)
-        self.atom_params.view_dialog = True
+        self.atom_params.show_dialog = True
         self.atom_params_bind.update_in_view(self.atom_params)
 
     def use_isotope(self):
-        self.atom_params.view_dialog = False
+        self.atom_params.show_dialog = False
         self.atom_params_bind.update_in_view(self.atom_params)
         self.periodic_table_view_model.use_isotope(self.atom_params.symbol)

--- a/src/NeuXtalViz/view_models/crystal_structure_tools.py
+++ b/src/NeuXtalViz/view_models/crystal_structure_tools.py
@@ -26,7 +26,9 @@ class CrystalStructureScatterers(BaseModel):
     scatterers: List[List[str | float]] = [[]]
     columns: List[str] = ["atm", "x", "y", "z", "occ", "U"]
 
-    @computed_field(return_type=List[Dict[str, str | int | float]], alias="scatterer_dict")
+    @computed_field(
+        return_type=List[Dict[str, str | int | float]], alias="scatterer_dict"
+    )
     def scatterer_dict(self):
         res = []
         for idx, row in enumerate(self.scatterers):
@@ -51,7 +53,9 @@ class CrystalStructureFactors(BaseModel):
         super().__init__(**data)
         self._row_data = row_data
 
-    @computed_field(return_type=List[Dict[str, str | int | float]], alias="factors_dict")
+    @computed_field(
+        return_type=List[Dict[str, str | int | float]], alias="factors_dict"
+    )
     def factors_dict(self):
         if self._row_data is None:
             return []
@@ -60,7 +64,7 @@ class CrystalStructureFactors(BaseModel):
             F2s = [F2s] * len(hkls)
             ds = [ds] * len(hkls)
         res = []
-        for (hkl, d, F2) in zip(hkls, ds, F2s):
+        for hkl, d, F2 in zip(hkls, ds, F2s):
             row = {}
             row["h"] = float(hkl[0])
             row["k"] = float(hkl[1])
@@ -96,7 +100,9 @@ class LatticeConstants(BaseModel):
 
 
 class CrystalStructureControls(BaseModel):
-    crystal_system: CrystalSystemOptions = Field(default=CrystalSystemOptions.triclinic, title="Crystal System")
+    crystal_system: CrystalSystemOptions = Field(
+        default=CrystalSystemOptions.triclinic, title="Crystal System"
+    )
     space_group_options: List[str] = []
     space_group: str = ""
     setting_options: List[str] = []
@@ -108,15 +114,17 @@ class CrystalStructureControls(BaseModel):
     formula: Optional[str] = Field(default=None, title="Z")
     z: Optional[int] = Field(default=None, title="Ω")
     vol: Optional[float] = Field(default=None, title="Å^3")
-    minimum_d_spacing: Optional[float] = Field(default=None, ge=0.1, le=1000, title="d(min), Å")
-    h: Optional[float] = Field(default=None, ge=-100, le=100)
-    k: Optional[float] = Field(default=None, ge=-100, le=100)
-    l: Optional[float] = Field(default=None, ge=-100, le=100)
+    minimum_d_spacing: Optional[float] = Field(
+        default=None, ge=0.1, le=1000, title="d(min), Å"
+    )
+    h: Optional[float] = Field(default=None, ge=-100, le=100, title="h")
+    k: Optional[float] = Field(default=None, ge=-100, le=100, title="k")
+    l: Optional[float] = Field(default=None, ge=-100, le=100, title="l")
 
-    @field_validator("minimum_d_spacing", "h", "k", "l", mode='before')
+    @field_validator("minimum_d_spacing", "h", "k", "l", mode="before")
     @classmethod
     def allow_empty_string(cls, v):
-        if v == '':
+        if v == "":
             return None
         return v
 
@@ -130,7 +138,7 @@ class SelectedAtom(BaseModel):
     name: Optional[str] = None
 
 
-class CrystalStructureViewModel():
+class CrystalStructureViewModel:
     def __init__(self, model, binding):
         self.cs_controls = CrystalStructureControls()
         self.cs_atoms = CrystalStructureAtoms()
@@ -141,7 +149,9 @@ class CrystalStructureViewModel():
         self.vis_viewmodel = None
         self.binding = binding
 
-        self.cs_cis_file_bind = binding.new_bind(self.cis_file, callback_after_update=self.load_CIF)
+        self.cs_cis_file_bind = binding.new_bind(
+            self.cis_file, callback_after_update=self.load_CIF
+        )
 
         self.cs_controls_bind = binding.new_bind(
             self.cs_controls, callback_after_update=self.process_cs_updates
@@ -164,7 +174,10 @@ class CrystalStructureViewModel():
         if self.key_updated("lattice_constants", True, results):
             self.update_parameters()
         if self.key_updated("current_scatterer_row", True, results):
-            if self.cs_controls.current_scatterer_row and self.cs_controls.current_scatterer_row[0] >= 0:
+            if (
+                self.cs_controls.current_scatterer_row
+                and self.cs_controls.current_scatterer_row[0] >= 0
+            ):
                 self.select_row(self.cs_controls.current_scatterer_row[0])
             else:
                 self.select_row(None)
@@ -179,7 +192,7 @@ class CrystalStructureViewModel():
     def set_vis_viewmodel(self, vis_viewmodel: NeuXtalVizViewModel):
         self.vis_viewmodel = vis_viewmodel
 
-    def set_perioric_table_viewmodel(self, pt_viewmodel: 'PeriodicTableViewModel'):
+    def set_perioric_table_viewmodel(self, pt_viewmodel: "PeriodicTableViewModel"):
         self.pt_viewmodel = pt_viewmodel
 
     def get_crystal_system_option_list(self):
@@ -189,7 +202,8 @@ class CrystalStructureViewModel():
         if row is not None:
             self.cs_controls.current_scatterer_row = [row]
             self.cs_controls.current_scatterer = self.cs_scatterers.scatterers[
-                self.cs_controls.current_scatterer_row[0]]
+                self.cs_controls.current_scatterer_row[0]
+            ]
         else:
             self.cs_controls.current_scatterer = [None] * 6
         self.cs_controls_bind.update_in_view(self.cs_controls)
@@ -211,11 +225,15 @@ class CrystalStructureViewModel():
 
     def generate_groups(self):
         system = self.cs_controls.crystal_system
-        self.cs_controls.space_group_options = self.model.generate_space_groups_from_crystal_system(system)
+        self.cs_controls.space_group_options = (
+            self.model.generate_space_groups_from_crystal_system(system)
+        )
 
     def generate_settings(self):
         no = self.cs_controls.space_group
-        self.cs_controls.setting_options = self.model.generate_settings_from_space_group(no)
+        self.cs_controls.setting_options = (
+            self.model.generate_settings_from_space_group(no)
+        )
 
     def load_CIF_process(self, progress):
         progress("Loading CIF...", 10)
@@ -226,7 +244,9 @@ class CrystalStructureViewModel():
         self.cs_controls.crystal_system = self.model.get_crystal_system()
         self.cs_controls.space_group = self.model.get_space_group()
         self.cs_controls.setting = self.model.get_setting()
-        self.cs_controls.lattice_constants.from_array(self.model.get_lattice_constants())
+        self.cs_controls.lattice_constants.from_array(
+            self.model.get_lattice_constants()
+        )
         self.cs_scatterers.scatterers = self.model.get_scatterers()
         self.cs_controls.current_scatterer_row = []
         self.cs_controls.current_scatterer = [None] * 6
@@ -268,12 +288,19 @@ class CrystalStructureViewModel():
             self.vis_viewmodel.update_invalid()
 
     def update_atoms(self):
-        self.cs_scatterers.scatterers[self.cs_controls.current_scatterer_row[0]] = self.cs_controls.current_scatterer
-        self.model.set_crystal_structure(self.cs_controls.lattice_constants.to_array(), self.cs_controls.setting,
-                                         self.cs_scatterers.scatterers)
+        self.cs_scatterers.scatterers[self.cs_controls.current_scatterer_row[0]] = (
+            self.cs_controls.current_scatterer
+        )
+        self.model.set_crystal_structure(
+            self.cs_controls.lattice_constants.to_array(),
+            self.cs_controls.setting,
+            self.cs_scatterers.scatterers,
+        )
 
         atoms_dict = self.model.generate_atom_positions()
-        self.cs_atoms.atoms_dict = atoms_dict  # {key: list(value) for key, value in atoms_dict.items()}
+        self.cs_atoms.atoms_dict = (
+            atoms_dict  # {key: list(value) for key, value in atoms_dict.items()}
+        )
         self.cs_controls.formula, z = self.model.get_chemical_formula_z_parameter()
         self.cs_controls.z = int(z)
 
@@ -329,14 +356,20 @@ class CrystalStructureViewModel():
             self.cs_factors_bind.update_in_view(res)
 
     def calculate_hkl_process(self, progress):
-        hkl_ok = self.cs_controls.h is not None and self.cs_controls.k is not None and self.cs_controls.l is not None
+        hkl_ok = (
+            self.cs_controls.h is not None
+            and self.cs_controls.k is not None
+            and self.cs_controls.l is not None
+        )
 
         if hkl_ok:
             progress("Processing...", 1)
 
             progress("Calculating equivalents...", 10)
 
-            hkls, d, F2 = self.model.calculate_F2(self.cs_controls.h, self.cs_controls.k, self.cs_controls.l)
+            hkls, d, F2 = self.model.calculate_F2(
+                self.cs_controls.h, self.cs_controls.k, self.cs_controls.l
+            )
 
             progress("Equivalents calculated...", 99)
 

--- a/src/NeuXtalViz/view_models/crystal_structure_tools.py
+++ b/src/NeuXtalViz/view_models/crystal_structure_tools.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Tuple, Dict, Any, Optional
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, computed_field
 
 from NeuXtalViz.view_models.base_view_model import NeuXtalVizViewModel
 
@@ -22,10 +22,43 @@ class CrystalSystemOptions(str, Enum):
 
 class CrystalStructureScatterers(BaseModel):
     scatterers: List[List[str | float]] = [[]]
+    columns: List[str] = ["atm", "x", "y", "z", "occ", "U"]
+
+    @computed_field(return_type=List[Dict[str, str | int | float]], alias="scatterer_dict")
+    def scatterer_dict(self):
+        res = []
+        for idx, row in enumerate(self.scatterers):
+            if not row:
+                continue
+            d = {"index": idx}
+            for i, val in enumerate(row):
+                d[self.columns[i]] = val
+            res.append(d)
+        return res
+
+    @computed_field(return_type=List[Dict[str, str | float]], alias="scatterer_header")
+    def scatterer_header(self):
+        return [{"title": value, "value": value} for value in self.columns]
 
 
 class CisFile(BaseModel):
     path: str = ""
+
+
+class LatticeConstants(BaseModel):
+    a: float = Field(default=0.1, title="a", ge=0.1, le=1000)
+    b: float = Field(default=0.1, title="b", ge=0.1, le=1000)
+    c: float = Field(default=0.1, title="c", ge=0.1, le=1000)
+    alpha: float = Field(default=10, title="α", ge=10, le=170)
+    beta: float = Field(default=10, title="β", ge=10, le=170)
+    gamma: float = Field(default=10, title="ɣ", ge=10, le=170)
+
+    def to_array(self) -> List[float]:
+        return [self.a, self.b, self.c, self.alpha, self.beta, self.gamma]
+
+    def from_array(self, lattice_constants: List[float]) -> "LatticeConstants":
+        self.a, self.b, self.c, self.alpha, self.beta, self.gamma = lattice_constants
+        return self
 
 
 class CrystalStructureControls(BaseModel):
@@ -34,10 +67,10 @@ class CrystalStructureControls(BaseModel):
     space_group: str = ""
     setting_options: List[str] = []
     setting: str = ""
-    lattice_constants: Optional[Tuple[float, float, float, float, float, float]] = None
-    current_scatterer: Optional[List[str | float]] = None
-    current_scatterer_row: Optional[int] = None
-    constrain_parameters: List[bool] = []
+    lattice_constants: LatticeConstants = LatticeConstants()
+    current_scatterer: List[str | float | None] = [None]*6
+    current_scatterer_row: List[int] = []
+    constrain_parameters: List[bool] = [True] * 6
     formula: str = ""
     z: int = None
     vol: float = 0
@@ -79,7 +112,7 @@ class CrystalStructureViewModel():
         self.cs_controls_bind = binding.new_bind(
             self.cs_controls, callback_after_update=self.process_cs_updates
         )
-        self.cs_scatterers_bind = binding.new_bind()
+        self.cs_scatterers_bind = binding.new_bind(self.cs_scatterers)
 
         self.cs_atoms_bind = binding.new_bind()
         self.cs_factors_bind = binding.new_bind()
@@ -89,15 +122,15 @@ class CrystalStructureViewModel():
         for update in results.get("updated", []):
             if partial and (f"{key}." in update or f"{key}[" in update):
                 return True
-            if not partial and key == update:
+            if key == update:
                 return True
         return False
 
     def process_cs_updates(self, results):
         if self.key_updated("lattice_constants", True, results):
             self.update_parameters()
-        if self.key_updated("current_scatterer_row", False, results):
-            self.select_row()
+        if self.key_updated("current_scatterer_row", True, results):
+            self.select_row(self.cs_controls.current_scatterer_row[0])
         if self.key_updated("current_scatterer", True, results):
             self.update_atoms()
 
@@ -115,16 +148,16 @@ class CrystalStructureViewModel():
     def get_crystal_system_option_list(self):
         return [e.value for e in CrystalSystemOptions]
 
-    def select_row(self):
-        if self.cs_controls.current_scatterer_row is not None:
-            self.cs_controls.current_scatterer = self.cs_scatterers.scatterers[self.cs_controls.current_scatterer_row]
-            self.cs_controls_bind.update_in_view(self.cs_controls)
+    def select_row(self, row):
+        self.cs_controls.current_scatterer_row[0] = row
+        self.cs_controls.current_scatterer = self.cs_scatterers.scatterers[self.cs_controls.current_scatterer_row[0]]
+        self.cs_controls_bind.update_in_view(self.cs_controls)
 
     def update_parameters(self):
-        params = self.cs_controls.lattice_constants
+        params = self.cs_controls.lattice_constants.to_array()
         params = self.model.update_parameters(params)
         self.model.update_lattice_parameters(*params)
-        self.cs_controls.lattice_constants = params
+        self.cs_controls.lattice_constants.from_array(params)
         vol = self.model.get_unit_cell_volume()
         self.cs_controls.vol = vol
         atom_dict = self.model.generate_atom_positions()
@@ -152,7 +185,7 @@ class CrystalStructureViewModel():
         self.cs_controls.crystal_system = self.model.get_crystal_system()
         self.cs_controls.space_group = self.model.get_space_group()
         self.cs_controls.setting = self.model.get_setting()
-        self.cs_controls.lattice_constants = self.model.get_lattice_constants()
+        self.cs_controls.lattice_constants.from_array(self.model.get_lattice_constants())
         self.cs_scatterers.scatterers = self.model.get_scatterers()
 
         self.generate_groups()
@@ -191,8 +224,8 @@ class CrystalStructureViewModel():
             self.vis_viewmodel.update_invalid()
 
     def update_atoms(self):
-        self.cs_scatterers.scatterers[self.cs_controls.current_scatterer_row] = self.cs_controls.current_scatterer
-        self.model.set_crystal_structure(self.cs_controls.lattice_constants, self.cs_controls.setting,
+        self.cs_scatterers.scatterers[self.cs_controls.current_scatterer_row[0]] = self.cs_controls.current_scatterer
+        self.model.set_crystal_structure(self.cs_controls.lattice_constants.to_array(), self.cs_controls.setting,
                                          self.cs_scatterers.scatterers)
 
         atoms_dict = self.model.generate_atom_positions()
@@ -220,7 +253,7 @@ class CrystalStructureViewModel():
     def calculate_F2_process(self, progress):
         d_min = self.cs_controls.minimum_d_spacing
 
-        params = self.cs_controls.lattice_constants
+        params = self.cs_controls.lattice_constants.to_array()
 
         if params is not None:
             progress("Processing...", 1)
@@ -269,7 +302,7 @@ class CrystalStructureViewModel():
             progress("Invalid parameters.", 0)
 
     def select_isotope(self):
-        if self.cs_controls.current_scatterer is None:
+        if self.cs_controls.current_scatterer[0] is None:
             return
         atom = self.cs_controls.current_scatterer[0]
         if atom:

--- a/src/NeuXtalViz/view_models/crystal_structure_tools.py
+++ b/src/NeuXtalViz/view_models/crystal_structure_tools.py
@@ -130,7 +130,10 @@ class CrystalStructureViewModel():
         if self.key_updated("lattice_constants", True, results):
             self.update_parameters()
         if self.key_updated("current_scatterer_row", True, results):
-            self.select_row(self.cs_controls.current_scatterer_row[0])
+            if self.cs_controls.current_scatterer_row:
+                self.select_row(self.cs_controls.current_scatterer_row[0])
+            else:
+                self.select_row(None)
         if self.key_updated("current_scatterer", True, results):
             self.update_atoms()
 
@@ -149,8 +152,10 @@ class CrystalStructureViewModel():
         return [e.value for e in CrystalSystemOptions]
 
     def select_row(self, row):
-        self.cs_controls.current_scatterer_row[0] = row
-        self.cs_controls.current_scatterer = self.cs_scatterers.scatterers[self.cs_controls.current_scatterer_row[0]]
+        if row is not None:
+            self.cs_controls.current_scatterer = self.cs_scatterers.scatterers[self.cs_controls.current_scatterer_row[0]]
+        else:
+            self.cs_controls.current_scatterer = [None]*6
         self.cs_controls_bind.update_in_view(self.cs_controls)
 
     def update_parameters(self):
@@ -187,6 +192,8 @@ class CrystalStructureViewModel():
         self.cs_controls.setting = self.model.get_setting()
         self.cs_controls.lattice_constants.from_array(self.model.get_lattice_constants())
         self.cs_scatterers.scatterers = self.model.get_scatterers()
+        self.cs_controls.current_scatterer_row = []
+        self.cs_controls.current_scatterer = [None]*6
 
         self.generate_groups()
         self.generate_settings()

--- a/src/NeuXtalViz/view_models/crystal_structure_tools.py
+++ b/src/NeuXtalViz/view_models/crystal_structure_tools.py
@@ -241,7 +241,7 @@ class CrystalStructureViewModel:
         self.model.load_CIF(self.cis_file.path)
 
         progress("Loading CIF...", 50)
-        self.cs_controls.crystal_system = self.model.get_crystal_system()
+        self.cs_controls.crystal_system = CrystalSystemOptions(self.model.get_crystal_system())
         self.cs_controls.space_group = self.model.get_space_group()
         self.cs_controls.setting = self.model.get_setting()
         self.cs_controls.lattice_constants.from_array(

--- a/src/NeuXtalViz/view_models/crystal_structure_tools.py
+++ b/src/NeuXtalViz/view_models/crystal_structure_tools.py
@@ -68,12 +68,12 @@ class CrystalStructureControls(BaseModel):
     setting_options: List[str] = []
     setting: str = ""
     lattice_constants: LatticeConstants = LatticeConstants()
-    current_scatterer: List[str | float | None] = [None]*6
+    current_scatterer: List[str | float | None] = [None] * 6
     current_scatterer_row: List[int] = []
     constrain_parameters: List[bool] = [True] * 6
-    formula: str = ""
-    z: int = None
-    vol: float = 0
+    formula: Optional[str] = Field(default=None,title="Z")
+    z: Optional[int] = Field(default=None,title="Ω")
+    vol: Optional[float] = Field(default=None,title="Å^3")
     minimum_d_spacing: Optional[float] = Field(default=None, ge=0.1, le=1000)
     h: Optional[float] = Field(default=None, ge=-100, le=100)
     k: Optional[float] = Field(default=None, ge=-100, le=100)
@@ -130,7 +130,7 @@ class CrystalStructureViewModel():
         if self.key_updated("lattice_constants", True, results):
             self.update_parameters()
         if self.key_updated("current_scatterer_row", True, results):
-            if self.cs_controls.current_scatterer_row:
+            if self.cs_controls.current_scatterer_row and self.cs_controls.current_scatterer_row[0] >= 0:
                 self.select_row(self.cs_controls.current_scatterer_row[0])
             else:
                 self.select_row(None)
@@ -153,9 +153,11 @@ class CrystalStructureViewModel():
 
     def select_row(self, row):
         if row is not None:
-            self.cs_controls.current_scatterer = self.cs_scatterers.scatterers[self.cs_controls.current_scatterer_row[0]]
+            self.cs_controls.current_scatterer_row = [row]
+            self.cs_controls.current_scatterer = self.cs_scatterers.scatterers[
+                self.cs_controls.current_scatterer_row[0]]
         else:
-            self.cs_controls.current_scatterer = [None]*6
+            self.cs_controls.current_scatterer = [None] * 6
         self.cs_controls_bind.update_in_view(self.cs_controls)
 
     def update_parameters(self):
@@ -193,7 +195,7 @@ class CrystalStructureViewModel():
         self.cs_controls.lattice_constants.from_array(self.model.get_lattice_constants())
         self.cs_scatterers.scatterers = self.model.get_scatterers()
         self.cs_controls.current_scatterer_row = []
-        self.cs_controls.current_scatterer = [None]*6
+        self.cs_controls.current_scatterer = [None] * 6
 
         self.generate_groups()
         self.generate_settings()
@@ -243,6 +245,7 @@ class CrystalStructureViewModel():
         self.cs_atoms.cell = self.model.get_unit_cell_transform()
 
         self.vis_viewmodel.set_transform(self.model.get_transform())
+        self.cs_scatterers_bind.update_in_view(self.cs_scatterers)
         self.cs_controls_bind.update_in_view(self.cs_controls)
         self.cs_atoms_bind.update_in_view(self.cs_atoms)
 

--- a/src/NeuXtalViz/view_models/periodic_table.py
+++ b/src/NeuXtalViz/view_models/periodic_table.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 class PeriodicTableParams(BaseModel):
     atom: str = "H"
-    show: bool = False
+    show: bool = True
 
 
 class PeriodicTableViewModel:
@@ -19,7 +19,7 @@ class PeriodicTableViewModel:
         self.model_params = PeriodicTableParams()
         self.binding = binding
         self.crystal_view_model = crystal_view_model
-        self.pt_model_bind = binding.new_bind()
+        self.pt_model_bind = binding.new_bind(self.model_params)
 
     def show_table(self, atom: str):
         self.model_params.atom = atom

--- a/src/NeuXtalViz/view_models/periodic_table.py
+++ b/src/NeuXtalViz/view_models/periodic_table.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 class PeriodicTableParams(BaseModel):
     atom: str = "H"
-    show: bool = True
+    show_dialog: bool = False
 
 
 class PeriodicTableViewModel:
@@ -23,7 +23,7 @@ class PeriodicTableViewModel:
 
     def show_table(self, atom: str):
         self.model_params.atom = atom
-        self.model_params.show = True
+        self.model_params.show_dialog = True
         self.pt_model_bind.update_in_view(self.model_params)
 
     def show_atom_dialog(self, atom):
@@ -33,6 +33,6 @@ class PeriodicTableViewModel:
         self.atom_view_model = atom_view_model
 
     def use_isotope(self, isotope_name):
-        self.model_params.show = False
+        self.model_params.show_dialog = False
         self.pt_model_bind.update_in_view(self.model_params)
         self.crystal_view_model.update_selected_atom(isotope_name)

--- a/src/NeuXtalViz/views/shared/base_plotter.py
+++ b/src/NeuXtalViz/views/shared/base_plotter.py
@@ -3,10 +3,10 @@ import pyvista as pv
 
 
 class BasePlotter:
-    def __init__(self, plotter):
-        self.plotter = plotter
+    def __init__(self, pv_plotter):
+        self.pv_plotter = pv_plotter
         self.camera_position = None
-        self.plotter.enable_parallel_projection()
+        self.pv_plotter.enable_parallel_projection()
 
     def change_projection(self, enable):
         """
@@ -14,9 +14,9 @@ class BasePlotter:
 
         """
         if enable:
-            self.plotter.enable_parallel_projection()
+            self.pv_plotter.enable_parallel_projection()
         else:
-            self.plotter.disable_parallel_projection()
+            self.pv_plotter.disable_parallel_projection()
 
     def reset_view(self, negative=False):
         """
@@ -24,9 +24,9 @@ class BasePlotter:
 
         """
 
-        self.plotter.reset_camera()
-        self.plotter.view_isometric(negative)
-        self.camera_position = self.plotter.camera_position
+        self.pv_plotter.reset_camera()
+        self.pv_plotter.view_isometric(negative)
+        self.camera_position = self.pv_plotter.camera_position
 
     def reset_camera(self):
         """
@@ -34,18 +34,18 @@ class BasePlotter:
 
         """
 
-        self.plotter.reset_camera()
+        self.pv_plotter.reset_camera()
 
     def clear_scene(self):
-        self.plotter.clear_plane_widgets()
-        self.plotter.clear_actors()
+        self.pv_plotter.clear_plane_widgets()
+        self.pv_plotter.clear_actors()
 
         if self.camera_position is not None:
-            self.camera_position = self.plotter.camera_position
+            self.camera_position = self.pv_plotter.camera_position
 
     def reset_scene(self):
         if self.camera_position is not None:
-            self.plotter.camera_position = self.camera_position
+            self.pv_plotter.camera_position = self.camera_position
         else:
             self.reset_view()
 
@@ -60,22 +60,22 @@ class BasePlotter:
 
         """
         if filename:
-            self.plotter.screenshot(filename)
+            self.pv_plotter.screenshot(filename)
 
     def show_axes(self, data):
         T, reciprocal_lattice, show_axes = data
 
         if not show_axes:
-            self.plotter.hide_axes()
+            self.pv_plotter.hide_axes()
         elif T is not None:
             t = pv._vtk.vtkMatrix4x4()
             for i in range(3):
                 for j in range(3):
                     t.SetElement(i, j, T[i, j])
             if reciprocal_lattice:
-                actor = self.plotter.add_axes(xlabel="a*", ylabel="b*", zlabel="c*")
+                actor = self.pv_plotter.add_axes(xlabel="a*", ylabel="b*", zlabel="c*")
             else:
-                actor = self.plotter.add_axes(xlabel="a", ylabel="b", zlabel="c")
+                actor = self.pv_plotter.add_axes(xlabel="a", ylabel="b", zlabel="c")
             actor.SetUserMatrix(t)
 
     def view_vector(self, vecs):
@@ -91,9 +91,9 @@ class BasePlotter:
 
         if len(vecs) == 2:
             vec = np.cross(vecs[0], vecs[1])
-            self.plotter.view_vector(vecs[0], vec)
+            self.pv_plotter.view_vector(vecs[0], vec)
         else:
-            self.plotter.view_vector(vecs)
+            self.pv_plotter.view_vector(vecs)
 
     def view_up_vector(self, vec):
         """
@@ -106,7 +106,7 @@ class BasePlotter:
 
         """
 
-        self.plotter.set_viewup(vec)
+        self.pv_plotter.set_viewup(vec)
 
     def view_xy(self):
         """
@@ -114,7 +114,7 @@ class BasePlotter:
 
         """
 
-        self.plotter.view_xy()
+        self.pv_plotter.view_xy()
 
     def view_yz(self):
         """
@@ -122,7 +122,7 @@ class BasePlotter:
 
         """
 
-        self.plotter.view_yz()
+        self.pv_plotter.view_yz()
 
     def view_zx(self):
         """
@@ -130,7 +130,7 @@ class BasePlotter:
 
         """
 
-        self.plotter.view_zx()
+        self.pv_plotter.view_zx()
 
     def view_yx(self):
         """
@@ -138,7 +138,7 @@ class BasePlotter:
 
         """
 
-        self.plotter.view_yx()
+        self.pv_plotter.view_yx()
 
     def view_zy(self):
         """
@@ -146,7 +146,7 @@ class BasePlotter:
 
         """
 
-        self.plotter.view_zy()
+        self.pv_plotter.view_zy()
 
     def view_xz(self):
         """
@@ -154,7 +154,7 @@ class BasePlotter:
 
         """
 
-        self.plotter.view_xz()
+        self.pv_plotter.view_xz()
 
     def set_position(self, pos):
         """
@@ -167,4 +167,4 @@ class BasePlotter:
 
         """
 
-        self.plotter.set_position(pos, reset=True)
+        self.pv_plotter.set_position(pos, reset=True)

--- a/src/NeuXtalViz/views/shared/crystal_structure_plotter.py
+++ b/src/NeuXtalViz/views/shared/crystal_structure_plotter.py
@@ -6,8 +6,8 @@ from NeuXtalViz.config.atoms import colors, radii
 
 
 class CrystalStructurePlotter:
-    def __init__(self, plotter, callback):
-        self.plotter = plotter
+    def __init__(self, pv_plotter, callback):
+        self.pv_plotter = pv_plotter
         self.callback = callback
 
     def highlight(self, index, dataset):
@@ -31,11 +31,11 @@ class CrystalStructurePlotter:
 
         """
 
-        self.plotter.reset_camera()
-        self.plotter.view_isometric()
+        self.pv_plotter.reset_camera()
+        self.pv_plotter.view_isometric()
 
     def add_atoms(self, atom_dict):
-        self.plotter.clear_actors()
+        self.pv_plotter.clear_actors()
 
         T = np.eye(4)
 
@@ -66,14 +66,14 @@ class CrystalStructurePlotter:
 
         multiblock = pv.MultiBlock(geoms)
 
-        _, mapper = self.plotter.add_composite(
+        _, mapper = self.pv_plotter.add_composite(
             multiblock, cmap=cmap, smooth_shading=True, show_scalar_bar=False
         )
 
         self.mapper = mapper
 
-        self.plotter.enable_block_picking(callback=self.highlight, side="left")
-        self.plotter.enable_block_picking(
+        self.pv_plotter.enable_block_picking(callback=self.highlight, side="left")
+        self.pv_plotter.enable_block_picking(
             callback=self.highlight, side="right"
         )
 
@@ -86,6 +86,6 @@ class CrystalStructurePlotter:
         mesh = pv.Box(bounds=(0, 1, 0, 1, 0, 1), level=0, quads=True)
         mesh.transform(T, inplace=True)
 
-        self.plotter.add_mesh(
+        self.pv_plotter.add_mesh(
             mesh, color="k", style="wireframe", render_lines_as_tubes=True
         )


### PR DESCRIPTION
Adding Trame version of Crystal Structure Tools. All functionality sholud be there, but please take a look.

Some changes to UI that I left unfinished:

- main tab - align right part so it fills the whole space
- main tab - load CIF button instead of input field
- periodic table - better close button, improve disabled isotopes visualization
- atom table - make it nicer
- in general - any changes to UI that make it look better

we can create separate issues if that is easier. In that case, just take a look at the code and functionality. 
 
